### PR TITLE
Not off gcd rogue kick was not displayed

### DIFF
--- a/AethysRotation_Rogue/Assassination.lua
+++ b/AethysRotation_Rogue/Assassination.lua
@@ -707,7 +707,8 @@ local function APL ()
     if ShouldReturn then return ShouldReturn; end
 
     -- Interrupts
-    Everyone.Interrupt(5, S.Kick, Settings.Commons.OffGCDasOffGCD.Kick, Interrupts);
+    ShouldReturn = Everyone.Interrupt(5, S.Kick, Settings.Commons.OffGCDasOffGCD.Kick, Interrupts);
+    if ShouldReturn then return ShouldReturn; end
 
     -- actions=variable,name=energy_regen_combined,value=energy.regen+poisoned_bleeds*(7+talent.venom_rush.enabled*3)%2
     Energy_Regen_Combined = Player:EnergyRegen() + Rogue.PoisonedBleeds() * (7 + (S.VenomRush:IsAvailable() and 3 or 0)) / 2;


### PR DESCRIPTION
When disabling off gcd kick it was never sugested to cast.