### PR TITLE
Changed Spell ID 0 on /hr unlock to 18282

### DIFF
--- a/HeroRotation/Main.lua
+++ b/HeroRotation/Main.lua
@@ -114,7 +114,7 @@
       HeroRotationDB.GUISettings["General.ScaleButtons"] = Multiplier;
     end
     -- Lock/Unlock
-    local LockSpell = Spell(0);
+    local LockSpell = Spell(18282);
     function HR.MainFrame:Unlock ()
       -- Grey Texture
       HR.ResetIcons();


### PR DESCRIPTION
ID 0 was not a spell and didn't show any icon so I was unable to move the frame, ID 18282 is called "Dummy Spell" and shows a cog icon, which seemed fitting.

![Dummy Spell](https://wow.zamimg.com/images/wow/icons/large/trade_engineering.jpg)