### PR TITLE
Fixing important Spellname Bug

### DIFF
--- a/HeroRotation_Druid/Balance.lua
+++ b/HeroRotation_Druid/Balance.lua
@@ -97,7 +97,7 @@ local function FutureAstralPower()
   if not Player:IsCasting() then
     return AstralPower
   else
-    if Player:IsCasting(S.NewnMoon) then
+    if Player:IsCasting(S.NewMoon) then
       return AstralPower + 10
     elseif Player:IsCasting(S.HalfMoon) then
       return AstralPower + 20


### PR DESCRIPTION
Fixing Spellname Bug for FutureAstralPower / actually every casting Spell counts as +10 FutureAstralPower cause wrong Spellname NewnMoon