### PR TITLE
[Demonology] 8.1 Update and Other Fixes

### DIFF
--- a/HeroRotation_Warlock/Demonology.lua
+++ b/HeroRotation_Warlock/Demonology.lua
@@ -187,23 +187,26 @@ end
 
 local function NetherPortalActive ()
   -- actions.nether_portal_active=grimoire_felguard,if=cooldown.summon_demonic_tyrant.remains<13|!equipped.132369
-  if S.GrimoireFelguard:IsCastable() and S.SummonTyrant:CooldownRemainsP() < 13 then
+  if S.GrimoireFelguard:IsCastable() and S.SummonTyrant:CooldownRemainsP() < 13 and FutureShard() > 0 then
     if HR.Cast(S.GrimoireFelguard) then return ""; end
   end
   -- actions.nether_portal_active+=/summon_vilefiend,if=cooldown.summon_demonic_tyrant.remains>40|cooldown.summon_demonic_tyrant.remains<12
-  if S.SummonVilefiend:IsCastable() and not Player:IsCasting(S.SummonVilefiend) and (S.SummonTyrant:CooldownRemainsP() > 40 or S.SummonTyrant:CooldownRemainsP() < 12) then
+  if S.SummonVilefiend:IsCastable() and not Player:IsCasting(S.SummonVilefiend) and FutureShard() > 0 and (S.SummonTyrant:CooldownRemainsP() > 40 or S.SummonTyrant:CooldownRemainsP() < 12) then
     if HR.Cast(S.SummonVilefiend) then return ""; end
   end
   -- actions.nether_portal_active+=/call_dreadstalkers,if=(cooldown.summon_demonic_tyrant.remains<9&buff.demonic_calling.remains)|(cooldown.summon_demonic_tyrant.remains<11&!buff.demonic_calling.remains)|cooldown.summon_demonic_tyrant.remains>14
-  if S.CallDreadStalkers:IsCastable()
+  if S.CallDreadStalkers:IsCastable() and (FutureShard() > 1 or (FutureShard() > 0 and Player:BuffRemainsP(S.DemonicCallingBuff) > 0))
+    and not Player:IsCasting(S.CallDreadStalkers)
     and ( (S.SummonTyrant:CooldownRemainsP() < 9 and Player:BuffRemainsP(S.DemonicCallingBuff) > 0)
     or (S.SummonTyrant:CooldownRemainsP() < 11 and Player:BuffRemainsP(S.DemonicCallingBuff) == 0)
     or S.SummonTyrant:CooldownRemainsP() < 14 ) then
       if HR.Cast(S.CallDreadStalkers) then return ""; end
   end
   -- actions.nether_portal_active+=/call_action_list,name=build_a_shard,if=soul_shard=1&(cooldown.call_dreadstalkers.remains<action.shadow_bolt.cast_time|(talent.bilescourge_bombers.enabled&cooldown.bilescourge_bombers.remains<action.shadow_bolt.cast_time))
-  ShouldReturn = BuildRot()
-  if ShouldReturn then return ShouldReturn; end
+  if FutureShard() == 1 and (S.CallDreadStalkers:CooldownRemainsP() < S.ShadowBolt:CastTime() or (S.BilescourgeBombers:IsAvailable() and S.BilescourgeBombers:CooldownRemainsP() < S.ShadowBolt:CastTime())) then
+    ShouldReturn = BuildRot()
+    if ShouldReturn then return ShouldReturn; end
+  end
   -- actions.nether_portal_active+=/hand_of_guldan,if=((cooldown.call_dreadstalkers.remains>action.demonbolt.cast_time)&(cooldown.call_dreadstalkers.remains>action.shadow_bolt.cast_time))&cooldown.nether_portal.remains>(160+action.hand_of_guldan.cast_time)
   if S.HandOfGuldan:IsCastable()
     and S.CallDreadStalkers:CooldownRemainsP() > S.Demonbolt:CastTime()
@@ -234,7 +237,7 @@ local function NetherPortalBuild ()
     if HR.Cast(S.NetherPortal) then return ""; end
   end
   -- actions.nether_portal_building+=/call_dreadstalkers
-  if S.CallDreadStalkers:IsCastable() then
+  if S.CallDreadStalkers:IsCastable() and (FutureShard() > 1 or (FutureShard() > 0 and Player:BuffRemainsP(S.DemonicCallingBuff) > 0)) and not Player:IsCasting(S.CallDreadStalkers) then
     if HR.Cast(S.CallDreadStalkers) then return ""; end
   end
   -- actions.nether_portal_building+=/hand_of_guldan,if=cooldown.call_dreadstalkers.remains>18&soul_shard>=3
@@ -312,7 +315,9 @@ local function APL ()
     -- Opener
     if Everyone.TargetIsValid() then
       -- actions.precombat+=/demonbolt
-      if Player:IsCasting(S.Demonbolt) and S.CallDreadStalkers:IsCastable() then
+      if Player:IsCasting(S.Demonbolt) and S.BilescourgeBombers:IsCastable() then
+        if HR.Cast(S.BilescourgeBombers) then return ""; end
+      elseif Player:IsCasting(S.Demonbolt) and S.CallDreadStalkers:IsCastable() then
         if HR.Cast(S.CallDreadStalkers) then return ""; end
       else
         if S.Demonbolt:IsCastable() then
@@ -364,22 +369,22 @@ local function APL ()
           if ShouldReturn then return ShouldReturn; end
         end
         -- actions+=/grimoire_felguard,if=cooldown.summon_demonic_tyrant.remains<13|!equipped.132369
-        if S.GrimoireFelguard:IsCastable() and S.SummonTyrant:CooldownRemainsP() < 13 then
+        if S.GrimoireFelguard:IsCastable() and S.SummonTyrant:CooldownRemainsP() < 13 and FutureShard() > 0 then
           if HR.Cast(S.GrimoireFelguard) then return ""; end
         end
-        -- actions+=/summon_vilefiend,if=equipped.132369|cooldown.summon_demonic_tyrant.remains>40|cooldown.summon_demonic_tyrant.remains<12
-        if S.SummonVilefiend:IsCastable() and not Player:IsCasting(S.SummonVilefiend) and (S.SummonTyrant:CooldownRemainsP() > 40 or S.SummonTyrant:CooldownRemainsP() < 12) then
-          if HR.Cast(S.SummonVilefiend) then return ""; end
-        end
         -- actions+=/call_dreadstalkers,if=equipped.132369|(cooldown.summon_demonic_tyrant.remains<9&buff.demonic_calling.remains)|(cooldown.summon_demonic_tyrant.remains<11&!buff.demonic_calling.remains)|cooldown.summon_demonic_tyrant.remains>14
-        if S.CallDreadStalkers:IsCastable()
+        if S.CallDreadStalkers:IsCastable() 
+          and (FutureShard() > 1 or (FutureShard() > 0 and Player:BuffRemainsP(S.DemonicCallingBuff) > 0) 
+          and not Player:IsCasting(S.CallDreadStalkers)
           and ( (S.SummonTyrant:CooldownRemainsP() < 9 and Player:BuffRemainsP(S.DemonicCallingBuff) > 0)
           or (S.SummonTyrant:CooldownRemainsP() < 11 and Player:BuffRemainsP(S.DemonicCallingBuff) == 0)
           or S.SummonTyrant:CooldownRemainsP() > 14 ) then
             if HR.Cast(S.CallDreadStalkers) then return ""; end
         end
-        -- actions+=/summon_demonic_tyrant,if=equipped.132369|(buff.dreadstalkers.remains>cast_time&(buff.wild_imps.stack>=3|prev_gcd.1.hand_of_guldan)&(soul_shard<3|buff.dreadstalkers.remains<gcd*2.7|buff.grimoire_felguard.remains<gcd*2.7))
+        -- actions+=/summon_demonic_tyrant,if=equipped.132369|(buff.dreadstalkers.remains>cast_time&(buff.wild_imps.stack>=3+talent.inner_demons.enabled+talent.demonic_consumption.enabled*3|prev_gcd.1.hand_of_guldan&(!talent.demonic_consumption.enabled|buff.wild_imps.stack>=3+talent.inner_demons.enabled))&(soul_shard<3|buff.dreadstalkers.remains<gcd*2.7|buff.grimoire_felguard.remains<gcd*2.7))
+        
         -- actions+=/power_siphon,if=buff.wild_imps.stack>=2&buff.demonic_core.stack<=2&buff.demonic_power.down&spell_targets.implosion<2
+        
         -- actions+=/doom,if=talent.doom.enabled&refreshable&time_to_die>(dot.doom.remains+30)
         if S.Doom:IsCastable() and Target:DebuffRefreshableCP(S.Doom) and Target:TimeToDie() > Target:DebuffRemainsP(S.Doom) + 30 then
           if HR.Cast(S.Doom) then return ""; end
@@ -402,6 +407,10 @@ local function APL ()
           or Player:BuffRemainsP(S.DemonicCoreBuff) < 5
           or Target:TimeToDie() < 25 ) then
             if HR.Cast(S.Demonbolt) then return ""; end
+        end
+        -- actions+=/bilescourge_bombers
+        if S.BilescourgeBombers:IsCastable() and FutureShard() > 1 then
+          if HR.Cast(S.BilescourgeBombers) then return ""; end
         end
         -- actions+=/call_action_list,name=build_a_shard
         ShouldReturn = BuildRot()

--- a/HeroRotation_Warlock/Demonology.lua
+++ b/HeroRotation_Warlock/Demonology.lua
@@ -22,63 +22,63 @@ local Warlock = HR.Commons.Warlock;
 if not Spell.Warlock then Spell.Warlock = {}; end
 Spell.Warlock.Demonology = {
   -- Racials
-  Berserking			= Spell(26297),
-  BloodFury				= Spell(20572),
-  Fireblood				= Spell(265221),
+  Berserking            = Spell(26297),
+  BloodFury             = Spell(20572),
+  Fireblood             = Spell(265221),
 
   -- Abilities
-  DrainLife 			= Spell(234153),
-  SummonTyrant			= Spell(265187),
-  SummonImp 			= Spell(688),
-  SummonFelguard  		= Spell(30146),
-  HandOfGuldan      	= Spell(105174),
-  ShadowBolt        	= Spell(686),
-  Demonbolt				= Spell(264178),
-  CallDreadStalkers 	= Spell(104316),
-  Fear 			    	= Spell(5782),
-  Implosion				= Spell(196277),
-  Shadowfury			= Spell(30283),
+  DrainLife             = Spell(234153),
+  SummonTyrant          = Spell(265187),
+  SummonImp             = Spell(688),
+  SummonFelguard        = Spell(30146),
+  HandOfGuldan          = Spell(105174),
+  ShadowBolt            = Spell(686),
+  Demonbolt             = Spell(264178),
+  CallDreadStalkers     = Spell(104316),
+  Fear                  = Spell(5782),
+  Implosion             = Spell(196277),
+  Shadowfury            = Spell(30283),
 
   -- Pet abilities
-  CauterizeMaster		= Spell(119905),--imp
-  Suffering				= Spell(119907),--voidwalker
-  SpellLock				= Spell(119910),--Dogi
-  Whiplash				= Spell(119909),--Bitch
-  AxeToss				= Spell(119914),--FelGuard
-  FelStorm		    	= Spell(89751),--FelGuard
+  CauterizeMaster       = Spell(119905),--imp
+  Suffering             = Spell(119907),--voidwalker
+  SpellLock             = Spell(119910),--Dogi
+  Whiplash              = Spell(119909),--Bitch
+  AxeToss               = Spell(119914),--FelGuard
+  FelStorm              = Spell(89751),--FelGuard
 
   -- Talents
-  Dreadlash				= Spell(264078),
-  DemonicStrength     	= Spell(267171),
-  BilescourgeBombers  	= Spell(267211),
+  Dreadlash             = Spell(264078),
+  DemonicStrength       = Spell(267171),
+  BilescourgeBombers    = Spell(267211),
 
-  DemonicCalling      	= Spell(205145),
-  PowerSiphon 	    	= Spell(264130),
-  Doom                	= Spell(265412),
+  DemonicCalling        = Spell(205145),
+  PowerSiphon           = Spell(264130),
+  Doom                  = Spell(265412),
 
-  DemonSkin     		= Spell(219272),
-  BurningRush			= Spell(111400),
-  DarkPact  			= Spell(108416),
+  DemonSkin             = Spell(219272),
+  BurningRush           = Spell(111400),
+  DarkPact              = Spell(108416),
 
-  FromTheShadows      	= Spell(267170),
-  SoulStrike          	= Spell(264057),
-  SummonVilefiend     	= Spell(264119),
+  FromTheShadows        = Spell(267170),
+  SoulStrike            = Spell(264057),
+  SummonVilefiend       = Spell(264119),
 
-  Darkfury            	= Spell(264874),
-  MortalCoil        	= Spell(6789),
-  DemonicCircle       	= Spell(268358),
+  Darkfury              = Spell(264874),
+  MortalCoil            = Spell(6789),
+  DemonicCircle         = Spell(268358),
 
-  InnerDemons         	= Spell(267216),
-  SoulConduit         	= Spell(215941),
-  GrimoireFelguard  	= Spell(111898),
+  InnerDemons           = Spell(267216),
+  SoulConduit           = Spell(215941),
+  GrimoireFelguard      = Spell(111898),
 
-  SacrificedSouls		= Spell(267214),
-  DemonicConsumption	= Spell(267215),
-  NetherPortal			= Spell(267217),
+  SacrificedSouls       = Spell(267214),
+  DemonicConsumption    = Spell(267215),
+  NetherPortal          = Spell(267217),
   NetherPortalBuff      = Spell(267218),
 
   -- Defensive
-  UnendingResolve 		= Spell(104773),
+  UnendingResolve       = Spell(104773),
 
   -- Azerite
   ForbiddenKnowledge    = Spell(279666),
@@ -86,9 +86,9 @@ Spell.Warlock.Demonology = {
   -- Utility
 
   -- Misc
-  DemonicCallingBuff  	= Spell(205146),
-  DemonicCoreBuff		= Spell(264173),
-  DemonicPowerBuff		= Spell(265273)
+  DemonicCallingBuff    = Spell(205146),
+  DemonicCoreBuff       = Spell(264173),
+  DemonicPowerBuff      = Spell(265273)
 };
 local S = Spell.Warlock.Demonology;
 
@@ -186,8 +186,8 @@ local function DoomDoTCycle()
   local TargetGUID = Target:GUID()
   for _, CycleUnit in pairs(Cache.Enemies[range]) do
     if CycleUnit:GUID() ~= TargetGUID and Everyone.UnitIsCycleValid(CycleUnit, 30, -CycleUnit:DebuffRemainsP(S.Doom)) and CycleUnit:DebuffRefreshableCP(S.Doom) then
-	  BestUnit, BestUnitTTD = CycleUnit, CycleUnit:TimeToDie()
-	end
+    BestUnit, BestUnitTTD = CycleUnit, CycleUnit:TimeToDie()
+  end
   end
   if BestUnit then
     HR.CastLeftNameplate(BestUnit, S.Doom)
@@ -305,11 +305,11 @@ local function ImplosionRot ()
   -- actions.implosion=implosion,if=(buff.wild_imps.stack>=6&(soul_shard<3|prev_gcd.1.call_dreadstalkers|buff.wild_imps.stack>=9|prev_gcd.1.bilescourge_bombers|(!prev_gcd.1.hand_of_guldan&!prev_gcd.2.hand_of_guldan))&!prev_gcd.1.hand_of_guldan&!prev_gcd.2.hand_of_guldan&buff.demonic_power.down)|(time_to_die<3&buff.wild_imps.stack>0)|(prev_gcd.2.call_dreadstalkers&buff.wild_imps.stack>2&!talent.demonic_calling.enabled)
   if S.Implosion:IsCastableP() and (WildImpsCount() >= 6 
     and (FutureShard() < 3 or Player:PrevGCDP(1, S.CallDreadStalkers) or WildImpsCount() >= 9 or Player:PrevGCDP(1, S.BilescourgeBombers)
-	or (not Player:PrevGCDP(1, S.HandOfGuldan) and not Player:PrevGCDP(2, S.HandOfGuldan)))
-	and not Player:PrevGCDP(1, S.HandOfGuldan) and not Player:PrevGCDP(2, S.HandOfGuldan) and Player:BuffRemainsP(S.DemonicPowerBuff) == 0)
-	or (Target:TimeToDie() < 3 and WildImpsCount() > 0)
-	or (Player:PrevGCDP(2, S.CallDreadStalkers) and WildImpsCount() > 2 and not S.DemonicCalling:IsAvailable()) then
-	  if HR.Cast(S.Implosion) then return ""; end
+  or (not Player:PrevGCDP(1, S.HandOfGuldan) and not Player:PrevGCDP(2, S.HandOfGuldan)))
+  and not Player:PrevGCDP(1, S.HandOfGuldan) and not Player:PrevGCDP(2, S.HandOfGuldan) and Player:BuffRemainsP(S.DemonicPowerBuff) == 0)
+  or (Target:TimeToDie() < 3 and WildImpsCount() > 0)
+  or (Player:PrevGCDP(2, S.CallDreadStalkers) and WildImpsCount() > 2 and not S.DemonicCalling:IsAvailable()) then
+    if HR.Cast(S.Implosion) then return ""; end
   end
   -- actions.implosion+=/grimoire_felguard,if=cooldown.summon_demonic_tyrant.remains<13|!equipped.132369
   if S.GrimoireFelguard:IsCastableP() and FutureShard() > 0 and S.SummonTyrant:CooldownRemainsP() < 13 then
@@ -319,10 +319,10 @@ local function ImplosionRot ()
   if S.CallDreadStalkers:IsCastableP() and S.CallDreadStalkers:CooldownRemainsP() < 1
     and (FutureShard() > 1 or (FutureShard() > 0 and Player:BuffRemainsP(S.DemonicCallingBuff) > 0))
     and not Player:IsCasting(S.CallDreadStalkers)
-	and ((S.SummonTyrant:CooldownRemainsP() < 9 and Player:BuffRemainsP(S.DemonicCallingBuff) > 0)
-	or (S.SummonTyrant:CooldownRemainsP() < 11 and Player:BuffRemainsP(S.DemonicCallingBuff) == 0)
-	or S.SummonTyrant:CooldownRemainsP() > 14) then
-	  if HR.Cast(S.CallDreadStalkers) then return ""; end
+  and ((S.SummonTyrant:CooldownRemainsP() < 9 and Player:BuffRemainsP(S.DemonicCallingBuff) > 0)
+  or (S.SummonTyrant:CooldownRemainsP() < 11 and Player:BuffRemainsP(S.DemonicCallingBuff) == 0)
+  or S.SummonTyrant:CooldownRemainsP() > 14) then
+    if HR.Cast(S.CallDreadStalkers) then return ""; end
   end
   -- actions.implosion+=/summon_demonic_tyrant
   if S.SummonTyrant:IsCastableP() then
@@ -335,15 +335,15 @@ local function ImplosionRot ()
   -- actions.implosion+=/hand_of_guldan,if=soul_shard>=3&(((prev_gcd.2.hand_of_guldan|buff.wild_imps.stack>=3)&buff.wild_imps.stack<9)|cooldown.summon_demonic_tyrant.remains<=gcd*2|buff.demonic_power.remains>gcd*2)
   if S.HandOfGuldan:IsCastableP() and FutureShard() >= 3 
     and (((Player:PrevGCDP(2, S.HandOfGuldan) or WildImpsCount() >= 3)
-	and WildImpsCount() < 9)
-	or S.SummonTyrant:CooldownRemainsP() <= Player:GCD() * 2 or Player:BuffRemainsP(S.DemonicPowerBuff) > Player:GCD() * 2) then
-	  if HR.Cast(S.HandOfGuldan) then return ""; end
+  and WildImpsCount() < 9)
+  or S.SummonTyrant:CooldownRemainsP() <= Player:GCD() * 2 or Player:BuffRemainsP(S.DemonicPowerBuff) > Player:GCD() * 2) then
+    if HR.Cast(S.HandOfGuldan) then return ""; end
   end
   -- actions.implosion+=/demonbolt,if=prev_gcd.1.hand_of_guldan&soul_shard>=1&(buff.wild_imps.stack<=3|prev_gcd.3.hand_of_guldan)&soul_shard<4&buff.demonic_core.up
   if S.Demonbolt:IsCastableP() and Player:PrevGCDP(1, S.HandOfGuldan) and FutureShard() >= 1
     and (WildImpsCount() <= 3 or Player:PrevGCDP(3, S.HandOfGuldan))
-	and FutureShard() < 4 and Player:BuffRemainsP(S.DemonicCoreBuff) > 0 then
-	  if HR.Cast(S.Demonbolt) then return ""; end
+  and FutureShard() < 4 and Player:BuffRemainsP(S.DemonicCoreBuff) > 0 then
+    if HR.Cast(S.Demonbolt) then return ""; end
   end
   -- actions.implosion+=/summon_vilefiend,if=(cooldown.summon_demonic_tyrant.remains>40&spell_targets.implosion<=2)|cooldown.summon_demonic_tyrant.remains<12
   if S.SummonVilefiend:IsCastableP() and not Player:IsCasting(S.SummonVilefiend) and FutureShard() > 0 and ((S.SummonTyrant:CooldownRemainsP() > 40 and Cache.EnemiesCount[range] <= 2) or S.SummonTyrant:CooldownRemainsP() < 12) then
@@ -360,18 +360,18 @@ local function ImplosionRot ()
   -- actions.implosion+=/demonbolt,if=soul_shard<=3&buff.demonic_core.up&(buff.demonic_core.stack>=3|buff.demonic_core.remains<=gcd*5.7)
   if S.Demonbolt:IsCastableP() and FutureShard() <= 3 and Player:BuffRemainsP(S.DemonicCoreBuff) > 0
     and (Player:BuffStackP(S.DemonicCoreBuff) >= 3 or Player:BuffRemainsP(S.DemonicCoreBuff) < Player:GCD() * 5.7) then
-	  if HR.Cast(S.Demonbolt) then return ""; end
+    if HR.Cast(S.Demonbolt) then return ""; end
   end
   -- actions.implosion+=/doom,cycle_targets=1,max_cycle_targets=7,if=refreshable
   if HR.AoEON() then
     if S.Doom:IsCastableP() and Target:DebuffRefreshableCP(S.Doom) and Target:TimeToDie() > 30 then
-	  if HR.Cast(S.Doom) then return ""; end
-	end
-	DoomDoTCycle()
+    if HR.Cast(S.Doom) then return ""; end
+  end
+  DoomDoTCycle()
   else
     if S.Doom:IsCastableP() and Target:DebuffRefreshableCP(S.Doom) and Target:TimeToDie() > 30 then
-	  if HR.Cast(S.Doom) then return ""; end
-	end
+    if HR.Cast(S.Doom) then return ""; end
+  end
   end
   -- actions.implosion+=/call_action_list,name=build_a_shard
   ShouldReturn = BuildRot()
@@ -400,7 +400,7 @@ local function APL ()
     -- actions.precombat=flask
     -- actions.precombat+=/food
     -- actions.precombat+=/augmentation
-	-- actions.precombat+=/inner_demons,if=talent.inner_demons.enabled
+  -- actions.precombat+=/inner_demons,if=talent.inner_demons.enabled
     -- actions.precombat+=/snapshot_stats
 
     -- Opener
@@ -479,16 +479,16 @@ local function APL ()
         end
         -- actions+=/summon_demonic_tyrant,if=equipped.132369|(buff.dreadstalkers.remains>cast_time&(buff.wild_imps.stack>=3+talent.inner_demons.enabled+talent.demonic_consumption.enabled*3|prev_gcd.1.hand_of_guldan&(!talent.demonic_consumption.enabled|buff.wild_imps.stack>=3+talent.inner_demons.enabled))&(soul_shard<3|buff.dreadstalkers.remains<gcd*2.7|buff.grimoire_felguard.remains<gcd*2.7))
         if S.SummonTyrant:IsCastableP() and DreadStalkersTime() > S.SummonTyrant:CastTime()
-		  and (WildImpsCount() >= 3 + num(S.InnerDemons:IsAvailable()) + (num(S.DemonicConsumption:IsAvailable())*3)
-		  or Player:PrevGCDP(1, S.HandOfGuldan) and (not S.DemonicConsumption:IsAvailable() or WildImpsCount() >= 3 + num(S.InnerDemons:IsAvailable())))
-		  and (FutureShard() < 3 or DreadStalkersTime() < Player:GCD() * 2.7 or GrimoireFelguardTime() < Player:GCD() * 2.7) then
-		    if HR.Cast(S.SummonTyrant) then return ""; end
-		end
+      and (WildImpsCount() >= 3 + num(S.InnerDemons:IsAvailable()) + (num(S.DemonicConsumption:IsAvailable())*3)
+      or Player:PrevGCDP(1, S.HandOfGuldan) and (not S.DemonicConsumption:IsAvailable() or WildImpsCount() >= 3 + num(S.InnerDemons:IsAvailable())))
+      and (FutureShard() < 3 or DreadStalkersTime() < Player:GCD() * 2.7 or GrimoireFelguardTime() < Player:GCD() * 2.7) then
+        if HR.Cast(S.SummonTyrant) then return ""; end
+    end
         -- actions+=/power_siphon,if=buff.wild_imps.stack>=2&buff.demonic_core.stack<=2&buff.demonic_power.down&spell_targets.implosion<2
         if S.PowerSiphon:IsCastableP() and WildImpsCount() >= 2 and Player:BuffStackP(S.DemonicCoreBuff) <= 2 
-		  and Player:BuffRemainsP(S.DemonicPowerBuff) == 0 and Cache.EnemiesCount[range] < 2 then
-		    if HR.Cast(S.PowerSiphon) then return ""; end
-		end
+      and Player:BuffRemainsP(S.DemonicPowerBuff) == 0 and Cache.EnemiesCount[range] < 2 then
+        if HR.Cast(S.PowerSiphon) then return ""; end
+    end
         -- actions+=/doom,if=talent.doom.enabled&refreshable&time_to_die>(dot.doom.remains+30)
         if S.Doom:IsCastableP() and Target:DebuffRefreshableCP(S.Doom) and Target:TimeToDie() > Target:DebuffRemainsP(S.Doom) + 30 then
           if HR.Cast(S.Doom) then return ""; end

--- a/HeroRotation_Warlock/Demonology.lua
+++ b/HeroRotation_Warlock/Demonology.lua
@@ -341,7 +341,7 @@ local function ImplosionRot ()
 	  if HR.Cast(S.Demonbolt) then return ""; end
   end
   -- actions.implosion+=/summon_vilefiend,if=(cooldown.summon_demonic_tyrant.remains>40&spell_targets.implosion<=2)|cooldown.summon_demonic_tyrant.remains<12
-  if S.SummonVilefiend:IsCastable() and not Player:IsCasting(S.SummonVilefiend) and ((S.SummonTyrant:CooldownRemainsP() > 40 and Cache.EnemiesCount[range] <= 2) or S.SummonTyrant:CooldownRemainsP() < 12) then
+  if S.SummonVilefiend:IsCastable() and not Player:IsCasting(S.SummonVilefiend) and FutureShard() > 0 and ((S.SummonTyrant:CooldownRemainsP() > 40 and Cache.EnemiesCount[range] <= 2) or S.SummonTyrant:CooldownRemainsP() < 12) then
     if HR.Cast(S.SummonVilefiend) then return ""; end
   end
   -- actions.implosion+=/bilescourge_bombers,if=cooldown.summon_demonic_tyrant.remains>9

--- a/HeroRotation_Warlock/Demonology.lua
+++ b/HeroRotation_Warlock/Demonology.lua
@@ -196,33 +196,37 @@ end
 
 local function CDs ()
   -- actions+=/berserking
-  if S.Berserking:IsAvailable() and S.Berserking:IsCastable() then
+  if S.Berserking:IsAvailable() and S.Berserking:IsCastableP() then
     if HR.Cast(S.Berserking, Settings.Commons.OffGCDasOffGCD.Racials) then return ""; end
   end
 end
 
 local function BuildRot ()
   -- actions.build_a_shard+=/soul_strike
-  if S.SoulStrike:IsCastable() then
+  if S.SoulStrike:IsCastableP() then
     if HR.Cast(S.SoulStrike) then return ""; end
   end
   -- actions.build_a_shard+=/shadow_bolt
-  if S.ShadowBolt:IsCastable() then
+  if S.ShadowBolt:IsCastableP() then
     if HR.Cast(S.ShadowBolt) then return ""; end
   end
 end
 
 local function NetherPortalActive ()
-  -- actions.nether_portal_active=grimoire_felguard,if=cooldown.summon_demonic_tyrant.remains<13|!equipped.132369
-  if S.GrimoireFelguard:IsCastable() and S.SummonTyrant:CooldownRemainsP() < 13 and FutureShard() > 0 then
+  -- actions.nether_portal_active=bilescourge_bombers
+  if S.BilescourgeBombers:IsCastableP() then
+    if HR.Cast(S.BilescourgeBombers) then return ""; end
+  end
+  -- actions.nether_portal_active+=/grimoire_felguard,if=cooldown.summon_demonic_tyrant.remains<13|!equipped.132369
+  if S.GrimoireFelguard:IsCastableP() and S.SummonTyrant:CooldownRemainsP() < 13 and FutureShard() > 0 then
     if HR.Cast(S.GrimoireFelguard) then return ""; end
   end
   -- actions.nether_portal_active+=/summon_vilefiend,if=cooldown.summon_demonic_tyrant.remains>40|cooldown.summon_demonic_tyrant.remains<12
-  if S.SummonVilefiend:IsCastable() and not Player:IsCasting(S.SummonVilefiend) and FutureShard() > 0 and (S.SummonTyrant:CooldownRemainsP() > 40 or S.SummonTyrant:CooldownRemainsP() < 12) then
+  if S.SummonVilefiend:IsCastableP() and not Player:IsCasting(S.SummonVilefiend) and FutureShard() > 0 and (S.SummonTyrant:CooldownRemainsP() > 40 or S.SummonTyrant:CooldownRemainsP() < 12) then
     if HR.Cast(S.SummonVilefiend) then return ""; end
   end
   -- actions.nether_portal_active+=/call_dreadstalkers,if=(cooldown.summon_demonic_tyrant.remains<9&buff.demonic_calling.remains)|(cooldown.summon_demonic_tyrant.remains<11&!buff.demonic_calling.remains)|cooldown.summon_demonic_tyrant.remains>14
-  if S.CallDreadStalkers:IsCastable() and (FutureShard() > 1 or (FutureShard() > 0 and Player:BuffRemainsP(S.DemonicCallingBuff) > 0))
+  if S.CallDreadStalkers:IsCastableP() and (FutureShard() > 1 or (FutureShard() > 0 and Player:BuffRemainsP(S.DemonicCallingBuff) > 0))
     and not Player:IsCasting(S.CallDreadStalkers)
     and ( (S.SummonTyrant:CooldownRemainsP() < 9 and Player:BuffRemainsP(S.DemonicCallingBuff) > 0)
     or (S.SummonTyrant:CooldownRemainsP() < 11 and Player:BuffRemainsP(S.DemonicCallingBuff) == 0)
@@ -234,23 +238,23 @@ local function NetherPortalActive ()
     ShouldReturn = BuildRot()
     if ShouldReturn then return ShouldReturn; end
   end
-  -- actions.nether_portal_active+=/hand_of_guldan,if=((cooldown.call_dreadstalkers.remains>action.demonbolt.cast_time)&(cooldown.call_dreadstalkers.remains>action.shadow_bolt.cast_time))&cooldown.nether_portal.remains>(160+action.hand_of_guldan.cast_time)
-  if S.HandOfGuldan:IsCastable()
+  -- actions.nether_portal_active+=/hand_of_guldan,if=((cooldown.call_dreadstalkers.remains>action.demonbolt.cast_time)&(cooldown.call_dreadstalkers.remains>action.shadow_bolt.cast_time))&cooldown.nether_portal.remains>(165+action.hand_of_guldan.cast_time)
+  if S.HandOfGuldan:IsCastableP()
     and (S.CallDreadStalkers:CooldownRemainsP() > S.Demonbolt:CastTime()
     and S.CallDreadStalkers:CooldownRemainsP() > S.ShadowBolt:CastTime())
-    and S.NetherPortal:CooldownRemainsP() > S.HandOfGuldan:CastTime() + 160 then
+    and S.NetherPortal:CooldownRemainsP() > S.HandOfGuldan:CastTime() + 165 then
       if HR.Cast(S.HandOfGuldan) then return ""; end
   end
-  -- actions.nether_portal_active+=/summon_demonic_tyrant,if=buff.nether_portal.remains<10&soul_shard=0
-  if S.SummonTyrant:IsCastable() and Player:BuffRemainsP(S.NetherPortalBuff) < 10 and FutureShard() == 0 then
+  -- actions.nether_portal_active+=/summon_demonic_tyrant,if=buff.nether_portal.remains<5&soul_shard=0
+  if S.SummonTyrant:IsCastableP() and Player:BuffRemainsP(S.NetherPortalBuff) < 5 and FutureShard() == 0 then
     if HR.Cast(S.SummonTyrant) then return ""; end
   end
-  -- actions.nether_portal_active+=/summon_demonic_tyrant,if=buff.nether_portal.remains<action.summon_demonic_tyrant.cast_time+5.5
-  if S.SummonTyrant:IsCastable() and Player:BuffRemainsP(S.NetherPortalBuff) < S.SummonTyrant:CastTime() + 5.5 then
+  -- actions.nether_portal_active+=/summon_demonic_tyrant,if=buff.nether_portal.remains<action.summon_demonic_tyrant.cast_time+0.5
+  if S.SummonTyrant:IsCastableP() and Player:BuffRemainsP(S.NetherPortalBuff) < S.SummonTyrant:CastTime() + 0.5 then
     if HR.Cast(S.SummonTyrant) then return ""; end
   end
   -- actions.nether_portal_active+=/demonbolt,if=buff.demonic_core.up
-  if S.Demonbolt:IsCastable() and Player:BuffRemainsP(S.DemonicCoreBuff) > 0 then
+  if S.Demonbolt:IsCastableP() and Player:BuffRemainsP(S.DemonicCoreBuff) > 0 then
     if HR.Cast(S.Demonbolt) then return ""; end
   end
   -- actions.nether_portal_active+=/call_action_list,name=build_a_shard
@@ -260,23 +264,23 @@ end
 
 local function NetherPortalBuild ()
   -- actions.nether_portal_building=nether_portal,if=soul_shard>=5&(!talent.power_siphon.enabled|buff.demonic_core.up)
-  if S.NetherPortal:IsCastable() and FutureShard() == 5 and (not S.PowerSiphon:IsAvailable() or Player:BuffRemainsP(S.DemonicCoreBuff) > 0) then
+  if S.NetherPortal:IsCastableP() and FutureShard() == 5 and (not S.PowerSiphon:IsAvailable() or Player:BuffRemainsP(S.DemonicCoreBuff) > 0) then
     if HR.Cast(S.NetherPortal) then return ""; end
   end
   -- actions.nether_portal_building+=/call_dreadstalkers
-  if S.CallDreadStalkers:IsCastable() and (FutureShard() > 1 or (FutureShard() > 0 and Player:BuffRemainsP(S.DemonicCallingBuff) > 0)) and not Player:IsCasting(S.CallDreadStalkers) then
+  if S.CallDreadStalkers:IsCastableP() and (FutureShard() > 1 or (FutureShard() > 0 and Player:BuffRemainsP(S.DemonicCallingBuff) > 0)) and not Player:IsCasting(S.CallDreadStalkers) then
     if HR.Cast(S.CallDreadStalkers) then return ""; end
   end
   -- actions.nether_portal_building+=/hand_of_guldan,if=cooldown.call_dreadstalkers.remains>18&soul_shard>=3
-  if S.HandOfGuldan:IsCastable() and S.CallDreadStalkers:CooldownRemainsP() > 18 and FutureShard() >= 3 then
+  if S.HandOfGuldan:IsCastableP() and S.CallDreadStalkers:CooldownRemainsP() > 18 and FutureShard() >= 3 then
     if HR.Cast(S.HandOfGuldan) then return ""; end
   end
   -- actions.nether_portal_building+=/power_siphon,if=buff.wild_imps.stack>=2&buff.demonic_core.stack<=2&buff.demonic_power.down&soul_shard>=3
-  if S.PowerSiphon:IsCastable() and WildImpsCount() >= 2 and Player:BuffStackP(S.DemonicCoreBuff) <= 2 and Player:BuffRemainsP(S.DemonicPowerBuff) == 0 and FutureShard() >= 3 then
+  if S.PowerSiphon:IsCastableP() and WildImpsCount() >= 2 and Player:BuffStackP(S.DemonicCoreBuff) <= 2 and Player:BuffRemainsP(S.DemonicPowerBuff) == 0 and FutureShard() >= 3 then
     if HR.Cast(S.PowerSiphon) then return ""; end
   end
   -- actions.nether_portal_building+=/hand_of_guldan,if=soul_shard>=5
-  if S.HandOfGuldan:IsCastable() and FutureShard() == 5 then
+  if S.HandOfGuldan:IsCastableP() and FutureShard() == 5 then
     if HR.Cast(S.HandOfGuldan) then return ""; end
   end
   -- actions.nether_portal_building+=/call_action_list,name=build_a_shard
@@ -290,8 +294,8 @@ local function NetherPortalRot ()
     ShouldReturn = NetherPortalBuild()
     if ShouldReturn then return ShouldReturn; end
   end
-  -- actions.nether_portal+=/call_action_list,name=nether_portal_active,if=cooldown.nether_portal.remains>160
-  if S.NetherPortal:CooldownRemainsP() > 160 then
+  -- actions.nether_portal+=/call_action_list,name=nether_portal_active,if=cooldown.nether_portal.remains>165
+  if S.NetherPortal:CooldownRemainsP() > 165 then
     ShouldReturn = NetherPortalActive()
     if ShouldReturn then return ShouldReturn; end
   end
@@ -299,7 +303,7 @@ end
 
 local function ImplosionRot ()
   -- actions.implosion=implosion,if=(buff.wild_imps.stack>=6&(soul_shard<3|prev_gcd.1.call_dreadstalkers|buff.wild_imps.stack>=9|prev_gcd.1.bilescourge_bombers|(!prev_gcd.1.hand_of_guldan&!prev_gcd.2.hand_of_guldan))&!prev_gcd.1.hand_of_guldan&!prev_gcd.2.hand_of_guldan&buff.demonic_power.down)|(time_to_die<3&buff.wild_imps.stack>0)|(prev_gcd.2.call_dreadstalkers&buff.wild_imps.stack>2&!talent.demonic_calling.enabled)
-  if S.Implosion:IsCastable() and (WildImpsCount() >= 6 
+  if S.Implosion:IsCastableP() and (WildImpsCount() >= 6 
     and (FutureShard() < 3 or Player:PrevGCDP(1, S.CallDreadStalkers) or WildImpsCount() >= 9 or Player:PrevGCDP(1, S.BilescourgeBombers)
 	or (not Player:PrevGCDP(1, S.HandOfGuldan) and not Player:PrevGCDP(2, S.HandOfGuldan)))
 	and not Player:PrevGCDP(1, S.HandOfGuldan) and not Player:PrevGCDP(2, S.HandOfGuldan) and Player:BuffRemainsP(S.DemonicPowerBuff) == 0)
@@ -308,11 +312,11 @@ local function ImplosionRot ()
 	  if HR.Cast(S.Implosion) then return ""; end
   end
   -- actions.implosion+=/grimoire_felguard,if=cooldown.summon_demonic_tyrant.remains<13|!equipped.132369
-  if S.GrimoireFelguard:IsCastable() and FutureShard() > 0 and S.SummonTyrant:CooldownRemainsP() < 13 then
+  if S.GrimoireFelguard:IsCastableP() and FutureShard() > 0 and S.SummonTyrant:CooldownRemainsP() < 13 then
     if HR.Cast(S.GrimoireFelguard) then return ""; end
   end
   -- actions.implosion+=/call_dreadstalkers,if=(cooldown.summon_demonic_tyrant.remains<9&buff.demonic_calling.remains)|(cooldown.summon_demonic_tyrant.remains<11&!buff.demonic_calling.remains)|cooldown.summon_demonic_tyrant.remains>14
-  if S.CallDreadStalkers:IsCastable() and S.CallDreadStalkers:CooldownRemainsP() < 1
+  if S.CallDreadStalkers:IsCastableP() and S.CallDreadStalkers:CooldownRemainsP() < 1
     and (FutureShard() > 1 or (FutureShard() > 0 and Player:BuffRemainsP(S.DemonicCallingBuff) > 0))
     and not Player:IsCasting(S.CallDreadStalkers)
 	and ((S.SummonTyrant:CooldownRemainsP() < 9 and Player:BuffRemainsP(S.DemonicCallingBuff) > 0)
@@ -321,51 +325,51 @@ local function ImplosionRot ()
 	  if HR.Cast(S.CallDreadStalkers) then return ""; end
   end
   -- actions.implosion+=/summon_demonic_tyrant
-  if S.SummonTyrant:IsCastable() then
+  if S.SummonTyrant:IsCastableP() then
     if HR.Cast(S.SummonTyrant) then return ""; end
   end
   -- actions.implosion+=/hand_of_guldan,if=soul_shard>=5
-  if S.HandOfGuldan:IsCastable() and FutureShard() == 5 then
+  if S.HandOfGuldan:IsCastableP() and FutureShard() == 5 then
     if HR.Cast(S.HandOfGuldan) then return ""; end
   end
   -- actions.implosion+=/hand_of_guldan,if=soul_shard>=3&(((prev_gcd.2.hand_of_guldan|buff.wild_imps.stack>=3)&buff.wild_imps.stack<9)|cooldown.summon_demonic_tyrant.remains<=gcd*2|buff.demonic_power.remains>gcd*2)
-  if S.HandOfGuldan:IsCastable() and FutureShard() >= 3 
+  if S.HandOfGuldan:IsCastableP() and FutureShard() >= 3 
     and (((Player:PrevGCDP(2, S.HandOfGuldan) or WildImpsCount() >= 3)
 	and WildImpsCount() < 9)
 	or S.SummonTyrant:CooldownRemainsP() <= Player:GCD() * 2 or Player:BuffRemainsP(S.DemonicPowerBuff) > Player:GCD() * 2) then
 	  if HR.Cast(S.HandOfGuldan) then return ""; end
   end
   -- actions.implosion+=/demonbolt,if=prev_gcd.1.hand_of_guldan&soul_shard>=1&(buff.wild_imps.stack<=3|prev_gcd.3.hand_of_guldan)&soul_shard<4&buff.demonic_core.up
-  if S.Demonbolt:IsCastable() and Player:PrevGCDP(1, S.HandOfGuldan) and FutureShard() >= 1
+  if S.Demonbolt:IsCastableP() and Player:PrevGCDP(1, S.HandOfGuldan) and FutureShard() >= 1
     and (WildImpsCount() <= 3 or Player:PrevGCDP(3, S.HandOfGuldan))
 	and FutureShard() < 4 and Player:BuffRemainsP(S.DemonicCoreBuff) > 0 then
 	  if HR.Cast(S.Demonbolt) then return ""; end
   end
   -- actions.implosion+=/summon_vilefiend,if=(cooldown.summon_demonic_tyrant.remains>40&spell_targets.implosion<=2)|cooldown.summon_demonic_tyrant.remains<12
-  if S.SummonVilefiend:IsCastable() and not Player:IsCasting(S.SummonVilefiend) and FutureShard() > 0 and ((S.SummonTyrant:CooldownRemainsP() > 40 and Cache.EnemiesCount[range] <= 2) or S.SummonTyrant:CooldownRemainsP() < 12) then
+  if S.SummonVilefiend:IsCastableP() and not Player:IsCasting(S.SummonVilefiend) and FutureShard() > 0 and ((S.SummonTyrant:CooldownRemainsP() > 40 and Cache.EnemiesCount[range] <= 2) or S.SummonTyrant:CooldownRemainsP() < 12) then
     if HR.Cast(S.SummonVilefiend) then return ""; end
   end
   -- actions.implosion+=/bilescourge_bombers,if=cooldown.summon_demonic_tyrant.remains>9
-  if S.BilescourgeBombers:IsCastable() and FutureShard() > 1 and S.SummonTyrant:CooldownRemainsP() > 9 then
+  if S.BilescourgeBombers:IsCastableP() and FutureShard() > 1 and S.SummonTyrant:CooldownRemainsP() > 9 then
     if HR.Cast(S.BilescourgeBombers) then return ""; end
   end
   -- actions.implosion+=/soul_strike,if=soul_shard<5&buff.demonic_core.stack<=2
-  if S.SoulStrike:IsCastable() and FutureShard() < 5 and Player:BuffStackP(S.DemonicCoreBuff) <= 2 then
+  if S.SoulStrike:IsCastableP() and FutureShard() < 5 and Player:BuffStackP(S.DemonicCoreBuff) <= 2 then
     if HR.Cast(S.SoulStrike) then return ""; end
   end
   -- actions.implosion+=/demonbolt,if=soul_shard<=3&buff.demonic_core.up&(buff.demonic_core.stack>=3|buff.demonic_core.remains<=gcd*5.7)
-  if S.Demonbolt:IsCastable() and FutureShard() <= 3 and Player:BuffRemainsP(S.DemonicCoreBuff) > 0
+  if S.Demonbolt:IsCastableP() and FutureShard() <= 3 and Player:BuffRemainsP(S.DemonicCoreBuff) > 0
     and (Player:BuffStackP(S.DemonicCoreBuff) >= 3 or Player:BuffRemainsP(S.DemonicCoreBuff) < Player:GCD() * 5.7) then
 	  if HR.Cast(S.Demonbolt) then return ""; end
   end
   -- actions.implosion+=/doom,cycle_targets=1,max_cycle_targets=7,if=refreshable
   if HR.AoEON() then
-    if S.Doom:IsCastable() and Target:DebuffRefreshableCP(S.Doom) and Target:TimeToDie() > 30 then
+    if S.Doom:IsCastableP() and Target:DebuffRefreshableCP(S.Doom) and Target:TimeToDie() > 30 then
 	  if HR.Cast(S.Doom) then return ""; end
 	end
 	DoomDoTCycle()
   else
-    if S.Doom:IsCastable() and Target:DebuffRefreshableCP(S.Doom) and Target:TimeToDie() > 30 then
+    if S.Doom:IsCastableP() and Target:DebuffRefreshableCP(S.Doom) and Target:TimeToDie() > 30 then
 	  if HR.Cast(S.Doom) then return ""; end
 	end
   end
@@ -381,7 +385,7 @@ local function APL ()
   Everyone.AoEToggleEnemiesUpdate();
 
   -- Defensives
-  if S.UnendingResolve:IsCastable() and Player:HealthPercentage() <= Settings.Demonology.UnendingResolveHP then
+  if S.UnendingResolve:IsCastableP() and Player:HealthPercentage() <= Settings.Demonology.UnendingResolveHP then
     if HR.Cast(S.UnendingResolve, Settings.Demonology.OffGCDasOffGCD.UnendingResolve) then return ""; end
   end
 
@@ -406,12 +410,12 @@ local function APL ()
         if HR.CastSuggested(I.BattlePotionofInt) then return ""; end
       end
       -- actions.precombat+=/demonbolt
-      if Player:IsCasting(S.Demonbolt) and S.BilescourgeBombers:IsCastable() then
+      if Player:IsCasting(S.Demonbolt) and S.BilescourgeBombers:IsCastableP() then
         if HR.Cast(S.BilescourgeBombers) then return ""; end
-      elseif Player:IsCasting(S.Demonbolt) and S.CallDreadStalkers:IsCastable() then
+      elseif Player:IsCasting(S.Demonbolt) and S.CallDreadStalkers:IsCastableP() then
         if HR.Cast(S.CallDreadStalkers) then return ""; end
       else
-        if S.Demonbolt:IsCastable() then
+        if S.Demonbolt:IsCastableP() then
           if HR.Cast(S.Demonbolt) then return ""; end
         end
       end
@@ -431,41 +435,41 @@ local function APL ()
         -- actions=potion,if=pet.demonic_tyrant.active|target.time_to_die<30
         -- actions+=/use_items,if=pet.demonic_tyrant.active|target.time_to_die<=15
         -- actions+=/berserking,if=pet.demonic_tyrant.active|target.time_to_die<=15
-        if S.Berserking:IsCastable() and (S.SummonTyrant:CooldownRemainsP() > 75 or Target:TimeToDie() <= 15) then
+        if S.Berserking:IsCastableP() and (S.SummonTyrant:CooldownRemainsP() > 75 or Target:TimeToDie() <= 15) then
           if HR.Cast(S.Berserking, Settings.Commons.OffGCDasOffGCD.Racials) then return ""; end
         end
         -- actions+=/blood_fury,if=pet.demonic_tyrant.active|target.time_to_die<=15
-        if S.BloodFury:IsCastable() and (S.SummonTyrant:CooldownRemainsP() > 75 or Target:TimeToDie() <= 15) then
+        if S.BloodFury:IsCastableP() and (S.SummonTyrant:CooldownRemainsP() > 75 or Target:TimeToDie() <= 15) then
           if HR.Cast(S.BloodFury, Settings.Commons.OffGCDasOffGCD.Racials) then return ""; end
         end
         -- actions+=/fireblood,if=pet.demonic_tyrant.active|target.time_to_die<=15
-        if S.Fireblood:IsCastable() and (S.SummonTyrant:CooldownRemainsP() > 75 or Target:TimeToDie() <= 15) then
+        if S.Fireblood:IsCastableP() and (S.SummonTyrant:CooldownRemainsP() > 75 or Target:TimeToDie() <= 15) then
           if HR.Cast(S.Fireblood, Settings.Commons.OffGCDasOffGCD.Racials) then return ""; end
         end
         -- actions+=/doom,if=!ticking&time_to_die>30&spell_targets.implosion<2
-        if S.Doom:IsCastable() and Cache.EnemiesCount[range] < 2 and not Target:DebuffRemainsP(S.Doom) and Target:TimeToDie() > 30 then
+        if S.Doom:IsCastableP() and Cache.EnemiesCount[range] < 2 and not Target:DebuffRemainsP(S.Doom) and Target:TimeToDie() > 30 then
           if HR.Cast(S.Doom) then return ""; end
         end
         -- actions+=/demonic_strength,if=(buff.wild_imps.stack<6|buff.demonic_power.up)|spell_targets.implosion<2
-        if S.DemonicStrength:IsCastable() and S.FelStorm:CooldownRemainsP() < 25 and ((WildImpsCount() < 6 or Player:BuffRemainsP(S.DemonicPowerBuff) > 0) or Cache.EnemiesCount[range] < 2) then
+        if S.DemonicStrength:IsCastableP() and S.FelStorm:CooldownRemainsP() < 25 and ((WildImpsCount() < 6 or Player:BuffRemainsP(S.DemonicPowerBuff) > 0) or Cache.EnemiesCount[range] < 2) then
           if HR.Cast(S.DemonicStrength) then return ""; end
         end
         -- actions+=/call_action_list,name=nether_portal,if=talent.nether_portal.enabled&spell_targets.implosion<=2
-        if S.NetherPortal:IsCastable() and Cache.EnemiesCount[range] <= 2 then
+        if S.NetherPortal:IsCastableP() and Cache.EnemiesCount[range] <= 2 then
           ShouldReturn = NetherPortalRot()
           if ShouldReturn then return ShouldReturn; end
         end
         -- actions+=/call_action_list,name=implosion,if=spell_targets.implosion>1
-        if S.Implosion:IsCastable() and Cache.EnemiesCount[range] > 1 then
+        if S.Implosion:IsCastableP() and Cache.EnemiesCount[range] > 1 then
           ShouldReturn = ImplosionRot()
           if ShouldReturn then return ShouldReturn; end
         end
         -- actions+=/grimoire_felguard,if=cooldown.summon_demonic_tyrant.remains<13|!equipped.132369
-        if S.GrimoireFelguard:IsCastable() and S.SummonTyrant:CooldownRemainsP() < 13 and FutureShard() > 0 then
+        if S.GrimoireFelguard:IsCastableP() and S.SummonTyrant:CooldownRemainsP() < 13 and FutureShard() > 0 then
           if HR.Cast(S.GrimoireFelguard) then return ""; end
         end
         -- actions+=/call_dreadstalkers,if=equipped.132369|(cooldown.summon_demonic_tyrant.remains<9&buff.demonic_calling.remains)|(cooldown.summon_demonic_tyrant.remains<11&!buff.demonic_calling.remains)|cooldown.summon_demonic_tyrant.remains>14
-        if S.CallDreadStalkers:IsCastable() 
+        if S.CallDreadStalkers:IsCastableP() 
           and (FutureShard() > 1 or (FutureShard() > 0 and Player:BuffRemainsP(S.DemonicCallingBuff) > 0))
           and not Player:IsCasting(S.CallDreadStalkers)
           and ( (S.SummonTyrant:CooldownRemainsP() < 9 and Player:BuffRemainsP(S.DemonicCallingBuff) > 0)
@@ -474,34 +478,34 @@ local function APL ()
             if HR.Cast(S.CallDreadStalkers) then return ""; end
         end
         -- actions+=/summon_demonic_tyrant,if=equipped.132369|(buff.dreadstalkers.remains>cast_time&(buff.wild_imps.stack>=3+talent.inner_demons.enabled+talent.demonic_consumption.enabled*3|prev_gcd.1.hand_of_guldan&(!talent.demonic_consumption.enabled|buff.wild_imps.stack>=3+talent.inner_demons.enabled))&(soul_shard<3|buff.dreadstalkers.remains<gcd*2.7|buff.grimoire_felguard.remains<gcd*2.7))
-        if S.SummonTyrant:IsCastable() and DreadStalkersTime() > S.SummonTyrant:CastTime()
+        if S.SummonTyrant:IsCastableP() and DreadStalkersTime() > S.SummonTyrant:CastTime()
 		  and (WildImpsCount() >= 3 + num(S.InnerDemons:IsAvailable()) + (num(S.DemonicConsumption:IsAvailable())*3)
 		  or Player:PrevGCDP(1, S.HandOfGuldan) and (not S.DemonicConsumption:IsAvailable() or WildImpsCount() >= 3 + num(S.InnerDemons:IsAvailable())))
 		  and (FutureShard() < 3 or DreadStalkersTime() < Player:GCD() * 2.7 or GrimoireFelguardTime() < Player:GCD() * 2.7) then
 		    if HR.Cast(S.SummonTyrant) then return ""; end
 		end
         -- actions+=/power_siphon,if=buff.wild_imps.stack>=2&buff.demonic_core.stack<=2&buff.demonic_power.down&spell_targets.implosion<2
-        if S.PowerSiphon:IsCastable() and WildImpsCount() >= 2 and Player:BuffStackP(S.DemonicCoreBuff) <= 2 
+        if S.PowerSiphon:IsCastableP() and WildImpsCount() >= 2 and Player:BuffStackP(S.DemonicCoreBuff) <= 2 
 		  and Player:BuffRemainsP(S.DemonicPowerBuff) == 0 and Cache.EnemiesCount[range] < 2 then
 		    if HR.Cast(S.PowerSiphon) then return ""; end
 		end
         -- actions+=/doom,if=talent.doom.enabled&refreshable&time_to_die>(dot.doom.remains+30)
-        if S.Doom:IsCastable() and Target:DebuffRefreshableCP(S.Doom) and Target:TimeToDie() > Target:DebuffRemainsP(S.Doom) + 30 then
+        if S.Doom:IsCastableP() and Target:DebuffRefreshableCP(S.Doom) and Target:TimeToDie() > Target:DebuffRemainsP(S.Doom) + 30 then
           if HR.Cast(S.Doom) then return ""; end
         end
         -- actions+=/hand_of_guldan,if=soul_shard>=5|(soul_shard>=3&cooldown.call_dreadstalkers.remains>4&(!talent.summon_vilefiend.enabled|cooldown.summon_vilefiend.remains>3))
-        if S.HandOfGuldan:IsCastable()
+        if S.HandOfGuldan:IsCastableP()
           and (FutureShard() == 5
           or (FutureShard() >= 3 and S.CallDreadStalkers:CooldownRemainsP() > 4
           and (not S.SummonVilefiend:IsAvailable() or S.SummonVilefiend:CooldownRemainsP() > 3))) then
             if HR.Cast(S.HandOfGuldan) then return ""; end
         end
         -- actions+=/soul_strike,if=soul_shard<5&buff.demonic_core.stack<=2
-        if S.SoulStrike:IsCastable() and FutureShard() < 5 and Player:BuffStackP(S.DemonicCoreBuff) <= 2 then
+        if S.SoulStrike:IsCastableP() and FutureShard() < 5 and Player:BuffStackP(S.DemonicCoreBuff) <= 2 then
           if HR.Cast(S.SoulStrike) then return ""; end
         end
         -- actions+=/demonbolt,if=soul_shard<=3&buff.demonic_core.up&((cooldown.summon_demonic_tyrant.remains<10|cooldown.summon_demonic_tyrant.remains>22)|buff.demonic_core.stack>=3|buff.demonic_core.remains<5|time_to_die<25)
-        if S.Demonbolt:IsCastable() and FutureShard() <= 3 and Player:BuffRemainsP(S.DemonicCoreBuff) > 0
+        if S.Demonbolt:IsCastableP() and FutureShard() <= 3 and Player:BuffRemainsP(S.DemonicCoreBuff) > 0
           and ( (S.SummonTyrant:CooldownRemainsP() < 10 or S.SummonTyrant:CooldownRemainsP() > 22)
           or Player:BuffStackP(S.DemonicCoreBuff) >= 3
           or Player:BuffRemainsP(S.DemonicCoreBuff) < 5
@@ -509,7 +513,7 @@ local function APL ()
             if HR.Cast(S.Demonbolt) then return ""; end
         end
         -- actions+=/bilescourge_bombers
-        if S.BilescourgeBombers:IsCastable() and FutureShard() > 1 then
+        if S.BilescourgeBombers:IsCastableP() and FutureShard() > 1 then
           if HR.Cast(S.BilescourgeBombers) then return ""; end
         end
         -- actions+=/call_action_list,name=build_a_shard

--- a/HeroRotation_Warlock/Demonology.lua
+++ b/HeroRotation_Warlock/Demonology.lua
@@ -194,12 +194,6 @@ local function DoomDoTCycle()
 end
 
 local function CDs ()
-  -- Demonic Tyrant
-  -- Remove once pet tracking is fixed
-  --[[if S.SummonTyrant:IsCastable(40) then
-    if HR.Cast(S.SummonTyrant, Settings.Demonology.GCDasOffGCD.SummonTyrant) then return ""; end
-  end]]
-
   -- actions+=/berserking
   if S.Berserking:IsAvailable() and S.Berserking:IsCastable() then
     if HR.Cast(S.Berserking, Settings.Commons.OffGCDasOffGCD.Racials) then return ""; end
@@ -347,7 +341,7 @@ local function ImplosionRot ()
 	  if HR.Cast(S.Demonbolt) then return ""; end
   end
   -- actions.implosion+=/summon_vilefiend,if=(cooldown.summon_demonic_tyrant.remains>40&spell_targets.implosion<=2)|cooldown.summon_demonic_tyrant.remains<12
-  if S.SummonVilefiend:IsCastable() and (S.SummonTyrant:CooldownRemainsP() > 40 and Cache.EnemiesCount[range] <= 2) or S.SummonTyrant:CooldownRemainsP() < 12 then
+  if S.SummonVilefiend:IsCastable() and not Player:IsCasting(S.SummonVilefiend) and ((S.SummonTyrant:CooldownRemainsP() > 40 and Cache.EnemiesCount[range] <= 2) or S.SummonTyrant:CooldownRemainsP() < 12) then
     if HR.Cast(S.SummonVilefiend) then return ""; end
   end
   -- actions.implosion+=/bilescourge_bombers,if=cooldown.summon_demonic_tyrant.remains>9
@@ -480,7 +474,7 @@ local function APL ()
 		  and (WildImpsCount() >= 3 + num(S.InnerDemons:IsAvailable()) + (num(S.DemonicConsumption:IsAvailable())*3)
 		  or Player:PrevGCDP(1, S.HandOfGuldan) and (not S.DemonicConsumption:IsAvailable() or WildImpsCount() >= 3 + num(S.InnerDemons:IsAvailable())))
 		  and (FutureShard() < 3 or DreadStalkersTime() < Player:GCD() * 2.7 or GrimoireFelguardTime() < Player:GCD() * 2.7) then
-		    if HR.Cast(S.SummonTyrant, Settings.Demonology.GCDasOffGCD.SummonTyrant) then return ""; end
+		    if HR.Cast(S.SummonTyrant) then return ""; end
 		end
         -- actions+=/power_siphon,if=buff.wild_imps.stack>=2&buff.demonic_core.stack<=2&buff.demonic_power.down&spell_targets.implosion<2
         if S.PowerSiphon:IsCastable() and WildImpsCount() >= 2 and Player:BuffStackP(S.DemonicCoreBuff) <= 2 

--- a/HeroRotation_Warlock/Demonology.lua
+++ b/HeroRotation_Warlock/Demonology.lua
@@ -479,16 +479,16 @@ local function APL ()
         end
         -- actions+=/summon_demonic_tyrant,if=equipped.132369|(buff.dreadstalkers.remains>cast_time&(buff.wild_imps.stack>=3+talent.inner_demons.enabled+talent.demonic_consumption.enabled*3|prev_gcd.1.hand_of_guldan&(!talent.demonic_consumption.enabled|buff.wild_imps.stack>=3+talent.inner_demons.enabled))&(soul_shard<3|buff.dreadstalkers.remains<gcd*2.7|buff.grimoire_felguard.remains<gcd*2.7))
         if S.SummonTyrant:IsCastableP() and DreadStalkersTime() > S.SummonTyrant:CastTime()
-      and (WildImpsCount() >= 3 + num(S.InnerDemons:IsAvailable()) + (num(S.DemonicConsumption:IsAvailable())*3)
-      or Player:PrevGCDP(1, S.HandOfGuldan) and (not S.DemonicConsumption:IsAvailable() or WildImpsCount() >= 3 + num(S.InnerDemons:IsAvailable())))
-      and (FutureShard() < 3 or DreadStalkersTime() < Player:GCD() * 2.7 or GrimoireFelguardTime() < Player:GCD() * 2.7) then
-        if HR.Cast(S.SummonTyrant) then return ""; end
-    end
+          and (WildImpsCount() >= 3 + num(S.InnerDemons:IsAvailable()) + (num(S.DemonicConsumption:IsAvailable())*3)
+          or Player:PrevGCDP(1, S.HandOfGuldan) and (not S.DemonicConsumption:IsAvailable() or WildImpsCount() >= 3 + num(S.InnerDemons:IsAvailable())))
+          and (FutureShard() < 3 or DreadStalkersTime() < Player:GCD() * 2.7 or GrimoireFelguardTime() < Player:GCD() * 2.7) then
+            if HR.Cast(S.SummonTyrant) then return ""; end
+        end
         -- actions+=/power_siphon,if=buff.wild_imps.stack>=2&buff.demonic_core.stack<=2&buff.demonic_power.down&spell_targets.implosion<2
         if S.PowerSiphon:IsCastableP() and WildImpsCount() >= 2 and Player:BuffStackP(S.DemonicCoreBuff) <= 2 
-      and Player:BuffRemainsP(S.DemonicPowerBuff) == 0 and Cache.EnemiesCount[range] < 2 then
-        if HR.Cast(S.PowerSiphon) then return ""; end
-    end
+          and Player:BuffRemainsP(S.DemonicPowerBuff) == 0 and Cache.EnemiesCount[range] < 2 then
+            if HR.Cast(S.PowerSiphon) then return ""; end
+        end
         -- actions+=/doom,if=talent.doom.enabled&refreshable&time_to_die>(dot.doom.remains+30)
         if S.Doom:IsCastableP() and Target:DebuffRefreshableCP(S.Doom) and Target:TimeToDie() > Target:DebuffRemainsP(S.Doom) + 30 then
           if HR.Cast(S.Doom) then return ""; end

--- a/HeroRotation_Warlock/Demonology.lua
+++ b/HeroRotation_Warlock/Demonology.lua
@@ -95,6 +95,7 @@ local S = Spell.Warlock.Demonology;
 -- Items
 if not Item.Warlock then Item.Warlock = {}; end
 Item.Warlock.Demonology = {
+  BattlePotionofInt     = Item(163222)
 };
 local I = Item.Warlock.Demonology;
 
@@ -397,10 +398,13 @@ local function APL ()
     -- actions.precombat+=/augmentation
 	-- actions.precombat+=/inner_demons,if=talent.inner_demons.enabled
     -- actions.precombat+=/snapshot_stats
-    -- actions.precombat+=/potion
 
     -- Opener
     if Everyone.TargetIsValid() then
+      -- actions.precombat+=/potion
+      if I.BattlePotionofInt:IsReady() and (Settings.Commons.UsePotions or Settings.Demonology.ShowBPoI) then
+        if HR.CastSuggested(I.BattlePotionofInt) then return ""; end
+      end
       -- actions.precombat+=/demonbolt
       if Player:IsCasting(S.Demonbolt) and S.BilescourgeBombers:IsCastable() then
         if HR.Cast(S.BilescourgeBombers) then return ""; end

--- a/HeroRotation_Warlock/Settings.lua
+++ b/HeroRotation_Warlock/Settings.lua
@@ -61,13 +61,7 @@
     },
     Demonology = {
       UnendingResolveHP = 20,
-      ShowPoPP = false,
-      Sephuz = {
-        ShadowFury = false,
-        MortalCoil = false,
-        Fear = false,
-        AxeToss = false
-      },
+      ShowBPoI = false,
       -- {Display GCD as OffGCD, ForceReturn}
       GCDasOffGCD = {
         -- Abilities
@@ -135,11 +129,7 @@
   -- Demonology
   CreatePanelOption("Slider", CP_Demonology, "APL.Warlock.Demonology.UnendingResolveHP", {0, 100, 1}, "Unending Resolve HP", "Set the Unending Resolve HP threshold.");
   CreateARPanelOptions(CP_Demonology, "APL.Warlock.Demonology");
-  CreatePanelOption("CheckButton", CP_Demonology, "APL.Warlock.Demonology.ShowPoPP", "Show Potion of Prolonged Power", "Enable this if you want it to show you when to use Potion of Prolonged Power.");
-  CreatePanelOption("CheckButton", CP_Demonology, "APL.Warlock.Demonology.Sephuz.ShadowFury", "Sephuz: Show Shadow Fury", "Enable this if you want it to show you when to use Shadow Fury to proc Sephuz's Secret (only when equipped).");
-  CreatePanelOption("CheckButton", CP_Demonology, "APL.Warlock.Demonology.Sephuz.MortalCoil", "Sephuz: Show Mortal Coil", "Enable this if you want it to show you when to use Mortal Coil to proc Sephuz's Secret (only when equipped).");
-  CreatePanelOption("CheckButton", CP_Demonology, "APL.Warlock.Demonology.Sephuz.Fear", "Sephuz: Show Fear", "Enable this if you want it to show you when to use Fear to proc Sephuz's Secret (only when equipped).");
-  CreatePanelOption("CheckButton", CP_Demonology, "APL.Warlock.Demonology.Sephuz.AxeToss", "Sephuz: Show Axe Toss", "Enable this if you want it to show you when to use Axe Toss (Felguard spell) to proc Sephuz's Secret (only when equipped).");
+  CreatePanelOption("CheckButton", CP_Demonology, "APL.Warlock.Demonology.ShowBPoI", "Show Battle Potion of Intellect", "Enable this if you want it to show you when to use Battle Potion of Intellect.");
   -- Affliction
   CreateARPanelOptions(CP_Affliction, "APL.Warlock.Affliction");
   -- CreatePanelOption("CheckButton", CP_Affliction, "APL.Warlock.Affliction.Sephuz.HowlOfTerror", "Sephuz: Show Howl Of Terror", "Enable this if you want it to show you when to use Howl Of Terror to proc Sephuz's Secret (only when equipped).");


### PR DESCRIPTION
- Updated to latest APL
- Fixed multiple places where FutureShard() wasn't checked, causing the
next suggested spell to not be suggested during the current cast
- Fixed Call Dreadstalkers to only be suggsted when you will have 2+
shards after the current cast (or 1 and Demonic Calling) and not be
suggested if currently casting Call Dreadstalkers
- Fixed Demonbolt opener to be followed by Bilescourge Bombers, if
available
- Fixed Grimoire Felguard to check for 1+ shards
- Still no Implosion rotation or Power Siphon suggestion because imp
tracking is a pain...