### PR TITLE
[Arms] Fixes for Logged Issues

### DIFF
--- a/HeroRotation_Warrior/Arms.lua
+++ b/HeroRotation_Warrior/Arms.lua
@@ -59,14 +59,15 @@ Spell.Warrior.Arms = {
   Fireblood                             = Spell(265221),
   AncestralCall                         = Spell(274738),
   Avatar                                = Spell(107574),
-  Massacre                              = Spell(281001)
+  Massacre                              = Spell(281001),
+  Pummel                                = Spell(6552)
 };
 local S = Spell.Warrior.Arms;
 
 -- Items
 if not Item.Warrior then Item.Warrior = {} end
 Item.Warrior.Arms = {
-  ProlongedPower                   = Item(142117)
+  BattlePotionofStrength                = Item(142117)
 };
 local I = Item.Warrior.Arms;
 
@@ -117,8 +118,14 @@ local function APL()
     -- augmentation
     -- snapshot_stats
     -- potion
-    if I.ProlongedPower:IsReady() and Settings.Commons.UsePotions then
-      if HR.CastSuggested(I.ProlongedPower) then return "prolonged_power 4"; end
+    if I.BattlePotionofStrength:IsReady() and Settings.Commons.UsePotions then
+      if HR.CastSuggested(I.BattlePotionofStrength) then return "battle_potion 4"; end
+    end
+  end
+  -- Add Pummel check
+  if Settings.General.InterruptEnabled and Target:IsInterruptible()  then
+    if S.Pummel:IsCastableP("Melee") then
+      if HR.Cast(S.Pummel, Settings.Commons.OffGCDasOffGCD.Pummel) then return "pummel interrupt"; end
     end
   end
   Execute = function()
@@ -140,7 +147,7 @@ local function APL()
     end
     -- deadly_calm
     if S.DeadlyCalm:IsCastableP() then
-      if HR.Cast(S.DeadlyCalm) then return "deadly_calm 30"; end
+      if HR.Cast(S.DeadlyCalm, Settings.Arms.OffGCDasOffGCD.DeadlyCalm) then return "deadly_calm 30"; end
     end
     -- bladestorm,if=rage<30&!buff.deadly_calm.up
     if S.Bladestorm:IsCastableP() and HR.CDsON() and (Player:Rage() < 30 and not Player:BuffP(S.DeadlyCalmBuff)) then
@@ -194,7 +201,7 @@ local function APL()
     end
     -- deadly_calm
     if S.DeadlyCalm:IsCastableP() then
-      if HR.Cast(S.DeadlyCalm) then return "deadly_calm 92"; end
+      if HR.Cast(S.DeadlyCalm, Settings.Arms.OffGCDasOffGCD.DeadlyCalm) then return "deadly_calm 92"; end
     end
     -- cleave
     if S.Cleave:IsReadyP() then
@@ -236,7 +243,7 @@ local function APL()
     end
     -- deadly_calm,if=(cooldown.bladestorm.remains>6|talent.ravager.enabled&cooldown.ravager.remains>6)&(cooldown.colossus_smash.remains<2|(talent.warbreaker.enabled&cooldown.warbreaker.remains<2))
     if S.DeadlyCalm:IsCastableP() and ((S.Bladestorm:CooldownRemainsP() > 6 or S.Ravager:IsAvailable() and S.Ravager:CooldownRemainsP() > 6) and (S.ColossusSmash:CooldownRemainsP() < 2 or (S.Warbreaker:IsAvailable() and S.Warbreaker:CooldownRemainsP() < 2))) then
-      if HR.Cast(S.DeadlyCalm) then return "deadly_calm 164"; end
+      if HR.Cast(S.DeadlyCalm, Settings.Arms.OffGCDasOffGCD.DeadlyCalm) then return "deadly_calm 164"; end
     end
     -- ravager,if=(raid_event.adds.up|raid_event.adds.in>target.time_to_die)&(cooldown.colossus_smash.remains<2|(talent.warbreaker.enabled&cooldown.warbreaker.remains<2))
     if S.Ravager:IsCastableP() and HR.CDsON() and (((Cache.EnemiesCount[8] > 1) or 10000000000 > Target:TimeToDie()) and (S.ColossusSmash:CooldownRemainsP() < 2 or (S.Warbreaker:IsAvailable() and S.Warbreaker:CooldownRemainsP() < 2))) then
@@ -263,7 +270,7 @@ local function APL()
       if HR.Cast(S.Cleave) then return "cleave 220"; end
     end
     -- execute,if=!raid_event.adds.up|(!talent.cleave.enabled&dot.deep_wounds.remains<2)|buff.sudden_death.react
-    if S.Execute:IsCastableP() and (not (Cache.EnemiesCount[8] > 1) or (not S.Cleave:IsAvailable() and Target:DebuffRemainsP(S.DeepWoundsDebuff) < 2) or bool(Player:BuffStackP(S.SuddenDeathBuff))) then
+    if S.Execute:IsCastableP() and (not (Cache.EnemiesCount[8] > 1) or (not S.Cleave:IsAvailable() and Target:DebuffRemainsP(S.DeepWoundsDebuff) < 2) or Player:BuffRemainsP(S.SuddenDeathBuff) > 0) then
       if HR.Cast(S.Execute) then return "execute 222"; end
     end
     -- mortal_strike,if=!raid_event.adds.up|(!talent.cleave.enabled&dot.deep_wounds.remains<2)
@@ -271,7 +278,7 @@ local function APL()
       if HR.Cast(S.MortalStrike) then return "mortal_strike 232"; end
     end
     -- whirlwind,if=raid_event.adds.up
-    if S.Whirlwind:IsReadyP() and ((Cache.EnemiesCount[8] > 1)) then
+    if S.Whirlwind:IsReadyP() and Cache.EnemiesCount[8] > 1 then
       if HR.Cast(S.Whirlwind) then return "whirlwind 240"; end
     end
     -- overpower
@@ -310,10 +317,10 @@ local function APL()
     end
     -- deadly_calm
     if S.DeadlyCalm:IsCastableP() then
-      if HR.Cast(S.DeadlyCalm) then return "deadly_calm 296"; end
+      if HR.Cast(S.DeadlyCalm, Settings.Arms.OffGCDasOffGCD.DeadlyCalm) then return "deadly_calm 296"; end
     end
     -- execute,if=buff.sudden_death.react
-    if S.Execute:IsCastableP() and (bool(Player:BuffStackP(S.SuddenDeathBuff))) then
+    if S.Execute:IsCastableP() and Player:BuffRemainsP(S.SuddenDeathBuff) > 0 then
       if HR.Cast(S.Execute) then return "execute 298"; end
     end
     -- bladestorm,if=cooldown.mortal_strike.remains&(!talent.deadly_calm.enabled|buff.deadly_calm.down)&((debuff.colossus_smash.up&!azerite.test_of_might.enabled)|buff.test_of_might.up)
@@ -360,8 +367,8 @@ local function APL()
     end
     -- auto_attack
     -- potion
-    if I.ProlongedPower:IsReady() and Settings.Commons.UsePotions then
-      if HR.CastSuggested(I.ProlongedPower) then return "prolonged_power 354"; end
+    if I.BattlePotionofStrength:IsReady() and Settings.Commons.UsePotions then
+      if HR.CastSuggested(I.BattlePotionofStrength) then return "prolonged_power 354"; end
     end
     -- blood_fury,if=debuff.colossus_smash.up
     if S.BloodFury:IsCastableP() and HR.CDsON() and (Target:DebuffP(S.ColossusSmashDebuff)) then
@@ -396,11 +403,11 @@ local function APL()
       if HR.Cast(S.SweepingStrikes) then return "sweeping_strikes 390"; end
     end
     -- run_action_list,name=hac,if=raid_event.adds.exists
-    if ((Cache.EnemiesCount[8] > 1)) then
+    if Cache.EnemiesCount[8] > 1 then
       return Hac();
     end
     -- run_action_list,name=five_target,if=spell_targets.whirlwind>4
-    if (Cache.EnemiesCount[8] > 4) then
+    if Cache.EnemiesCount[8] > 4 then
       return FiveTarget();
     end
     -- run_action_list,name=execute,if=(talent.massacre.enabled&target.health.pct<35)|target.health.pct<20

--- a/HeroRotation_Warrior/Arms.lua
+++ b/HeroRotation_Warrior/Arms.lua
@@ -67,7 +67,7 @@ local S = Spell.Warrior.Arms;
 -- Items
 if not Item.Warrior then Item.Warrior = {} end
 Item.Warrior.Arms = {
-  BattlePotionofStrength                = Item(142117)
+  BattlePotionofStrength                = Item(163224)
 };
 local I = Item.Warrior.Arms;
 

--- a/HeroRotation_Warrior/Settings.lua
+++ b/HeroRotation_Warrior/Settings.lua
@@ -39,6 +39,7 @@
       },
       OffGCDasOffGCD = {
         -- Abilities
+        DeadlyCalm = true,
         -- Items
       },
     },


### PR DESCRIPTION
- Fix for Issue herotc#333
-- Changed bool check for Sudden Death proc to a BuffRemainsP check,
which seems to react more reliably
- Fix for Issue herotc#330
-- Added Pummel interrupt code
- Could not duplicate Issue herotc#331
-- APL matches SimC, so I'm not sure how it's not optimized
- Changed Potion of Prolonged Power to Battle Potion of Strength
- Moved Deadly Calm from GCDasOffGCD to OffGCDasOffGCD