### PR TITLE
[Elemental] Corrects reaction prediction for lava burst

### DIFF
--- a/HeroRotation_Shaman/Elemental.lua
+++ b/HeroRotation_Shaman/Elemental.lua
@@ -449,7 +449,10 @@ function single_target()
     if HR.Cast(S.LightningBolt) then return "Cast LightningBolt" end
   end
   --actions.single_target+=/lava_burst,if=cooldown_react
-  if (S.LavaBurst:IsReady()) then
+  if (S.LavaBurst:IsReady() and not Player:IsCasting(S.LavaBurst)) then
+    if HR.Cast(S.LavaBurst) then return "Cast LavaBurst" end
+  end
+  if (S.LavaBurst:IsReady() and Player:IsCasting(S.LavaBurst) and Player:Buff(S.LavaSurgeBuff)) then
     if HR.Cast(S.LavaBurst) then return "Cast LavaBurst" end
   end
   --# Don't accidentally use Surge of Power with Flame Shock during single target.

--- a/HeroRotation_Shaman/Elemental.lua
+++ b/HeroRotation_Shaman/Elemental.lua
@@ -204,7 +204,7 @@ local function APL ()
         if HR.Cast(S.ElementalBlast) then return "Cast Elemental Blast" end
       end
       --actions.precombat+=/lava_burst,if=!talent.elemental_blast.enabled
-      if (not S.ElementalBlast:IsAvailable() and S.LavaBurst:IsReady()) then
+      if (not S.ElementalBlast:IsAvailable() and S.LavaBurst:IsReady() and not Player:IsCasting(S.LavaBurst)) then
         if HR.Cast(S.LavaBurst) then return "Cast Lava Burst" end
       end
     end


### PR DESCRIPTION
Current Behavior:

When lava burst is being checked, the cast prediction does not correctly predict any lower priority spells. If you are casting lava burst without a lava surge proc, it will predict that you should be casting lava burst next, even if it will go on cooldown.

The changes look for both cases:

1. if you aren't casting lava burst, but should
2. if you are casting lava burst and you have a lava surge proc waiting

To replicate: Cast lava burst without a proc or a higher priority spell on the queue, and it will show lava burst when it should show the next priority spell (ie LB/CL) or Earth shock if you are going to hit maelstrom.

Note: if a higher priority spell comes into priority (Flame shock etc) it will work properly, this only applies to lower priority spells.