### PR TITLE
[Outlaw] Do not cast Toxic Blade when at max combo points.

### DIFF
--- a/HeroRotation_Rogue/Assassination.lua
+++ b/HeroRotation_Rogue/Assassination.lua
@@ -298,7 +298,7 @@ local function CDs ()
         end
       end
       -- actions.cds+=/toxic_blade,if=dot.rupture.ticking
-      if S.ToxicBlade:IsCastable("Melee") and Target:DebuffP(S.Rupture) then
+      if S.ToxicBlade:IsCastable("Melee") and Target:DebuffP(S.Rupture) and Player:ComboPointsDeficit() > 0 then
         if HR.Cast(S.ToxicBlade) then return "Cast Toxic Blade"; end
       end
     end


### PR DESCRIPTION
Toxic Blade adds a combo point, so casting it when combo points are maxed results in lost CPs/DPS.