### PR TITLE
[Demonology] Fix Dcon Opener and Overrides

### DIFF
--- a/HeroRotation_Warlock/Demonology.lua
+++ b/HeroRotation_Warlock/Demonology.lua
@@ -48,6 +48,7 @@ Spell.Warlock.Demonology = {
   BloodFury                             = Spell(20572),
   Fireblood                             = Spell(265221),
   ExplosivePotential                    = Spell(275395),
+  BalefulInvocation                     = Spell(287059),
   DemonicConsumption                    = Spell(267215),
 };
 local S = Spell.Warlock.Demonology;

--- a/HeroRotation_Warlock/Demonology.lua
+++ b/HeroRotation_Warlock/Demonology.lua
@@ -146,7 +146,7 @@ local function APL()
   end
   DconEpOpener = function()
     -- hand_of_guldan,line_cd=30
-    if S.HandofGuldan:IsCastableP() then
+    if S.HandofGuldan:IsCastableP() and (HL.CombatTime() < 5 and Player:SoulShardsP() > 2) then
       if HR.Cast(S.HandofGuldan) then return "hand_of_guldan 18"; end
     end
     -- implosion,if=buff.wild_imps.stack>2&buff.explosive_potential.down
@@ -154,7 +154,7 @@ local function APL()
       if HR.Cast(S.Implosion) then return "implosion 20"; end
     end
     -- doom,line_cd=30
-    if S.Doom:IsCastableP() then
+    if S.Doom:IsCastableP() and (Target:DebuffRefreshableCP(S.DoomDebuff)) then
       if HR.Cast(S.Doom) then return "doom 26"; end
     end
     -- demonic_strength

--- a/HeroRotation_Warlock/Overrides.lua
+++ b/HeroRotation_Warlock/Overrides.lua
@@ -118,9 +118,7 @@
       if not Player:IsCasting() then
         return Shard
       else
-        if Player:IsCasting(SpellDemo.NetherPortal) then
-          return Shard - 3
-        elseif (Player:IsCasting(SpellDemo.CallDreadstalkers) and not Player:BuffP(SpellDemo.DemonicCallingBuff))
+        if (Player:IsCasting(SpellDemo.CallDreadstalkers) and not Player:BuffP(SpellDemo.DemonicCallingBuff))
             or  Player:IsCasting(SpellDemo.BilescourgeBombers) then
           return Shard - 2
         elseif (Player:IsCasting(SpellDemo.CallDreadstalkers) and Player:BuffP(SpellDemo.DemonicCallingBuff))

--- a/HeroRotation_Warlock/Overrides.lua
+++ b/HeroRotation_Warlock/Overrides.lua
@@ -114,22 +114,22 @@
   
   HL.AddCoreOverride ("Player.SoulShardsP",
     function (self)
-      local Shard = WarlockPowerBar_UnitPower(self.UnitID)
+      local Shard = Player:SoulShards()
       if not Player:IsCasting() then
         return Shard
       else
         if Player:IsCasting(SpellDemo.NetherPortal) then
           return Shard - 3
-        elseif (Player:IsCasting(SpellDemo.CallDreadStalkers) and not Player:BuffP(SpellDemo.DemonicCallingBuff))
+        elseif (Player:IsCasting(SpellDemo.CallDreadstalkers) and not Player:BuffP(SpellDemo.DemonicCallingBuff))
             or  Player:IsCasting(SpellDemo.BilescourgeBombers) then
           return Shard - 2
-        elseif (Player:IsCasting(SpellDemo.CallDreadStalkers) and Player:BuffP(SpellDemo.DemonicCallingBuff))
+        elseif (Player:IsCasting(SpellDemo.CallDreadstalkers) and Player:BuffP(SpellDemo.DemonicCallingBuff))
             or  Player:IsCasting(SpellDemo.SummonVilefiend)
-            or  Player:IsCasting(SpellDemo.SummonFelguard)
+            or  Player:IsCasting(SpellDemo.SummonPet)
             or  Player:IsCasting(SpellDemo.GrimoireFelguard) 
             or  Player:IsCasting(SpellDemo.NetherPortal) then
           return Shard - 1
-        elseif Player:IsCasting(SpellDemo.HandOfGuldan) then
+        elseif Player:IsCasting(SpellDemo.HandofGuldan) then
           if Shard > 3 then
             return Shard - 3
           else
@@ -141,13 +141,13 @@
           else
             return Shard + 2
           end
-        elseif Player:IsCasting(SpellDemo.Shadowbolt) then
+        elseif Player:IsCasting(SpellDemo.ShadowBolt) then
           if Shard == 5 then
             return Shard
           else
             return Shard + 1
           end
-        elseif Player:IsCasting(SpellDemo.SummonTyrant) and SpellDemo.BalefulInvocation:AzeriteEnabled() then 
+        elseif Player:IsCasting(SpellDemo.SummonDemonicTyrant) and SpellDemo.BalefulInvocation:AzeriteEnabled() then 
           return 5
         else
           return Shard


### PR DESCRIPTION
- Added checks on first HoG line within DconEPOpener to make it so it
should only be suggested once per opener
- Added DebuffRefreshableCP check to Doom within DconEPOpener to avoid
it being suggested repeatedly
- Fixed spell names within SoulShardsP override