### PR TITLE
Fix issue with Outlaw Font of Power calling erroneous cooldown function

### DIFF
--- a/HeroRotation_Rogue/Outlaw.lua
+++ b/HeroRotation_Rogue/Outlaw.lua
@@ -347,7 +347,7 @@ local function CDs ()
     end
 
     -- actions.cds+=/adrenaline_rush,if=!buff.adrenaline_rush.up&energy.time_to_max>1&(!equipped.azsharas_font_of_power|cooldown.latent_arcana.remains>20)
-    if S.AdrenalineRush:IsCastableP() and not Player:BuffP(S.AdrenalineRush) and EnergyTimeToMaxRounded() > 1 and (not I.FontOfPower:IsEquipped() or I.FontOfPower:CooldownRemainsP() > 20) then
+    if S.AdrenalineRush:IsCastableP() and not Player:BuffP(S.AdrenalineRush) and EnergyTimeToMaxRounded() > 1 and (not I.FontOfPower:IsEquipped() or I.FontOfPower:CooldownRemains() > 20) then
       if HR.Cast(S.AdrenalineRush, Settings.Outlaw.GCDasOffGCD.AdrenalineRush) then return "Cast Adrenaline Rush"; end
     end
 


### PR DESCRIPTION
Items do not have a `CooldownRemainsP` function like spells do.