### PR TITLE
Smoother Netherportal Gameplay and Cleanup

### DIFF
--- a/HeroRotation_Warlock/Affliction.lua
+++ b/HeroRotation_Warlock/Affliction.lua
@@ -202,13 +202,13 @@ local function Opener()
   if S.Agony:IsReady() and (Target:DebuffDown(S.AgonyDebuff)) then
     if Cast(S.Agony, nil, nil, not Target:IsSpellInRange(S.Agony)) then return "agony opener"; end
   end
-  -- corruption,if=!dot.corruption.ticking
-  if S.Corruption:IsReady() and (Target:DebuffDown(S.CorruptionDebuff)) then
-    if Cast(S.Corruption, nil, nil, not Target:IsSpellInRange(S.Corruption)) then return "corruption opener"; end
-  end
   -- siphon_life,if=!dot.siphon_life.ticking
   if S.SiphonLife:IsReady() and (Target:DebuffDown(S.SiphonLifeDebuff)) then
     if Cast(S.SiphonLife, nil, nil, not Target:IsSpellInRange(S.SiphonLife)) then return "siphon_life opener"; end
+  end
+  -- corruption,if=!dot.corruption.ticking
+  if S.Corruption:IsReady() and (Target:DebuffDown(S.CorruptionDebuff)) then
+    if Cast(S.Corruption, nil, nil, not Target:IsSpellInRange(S.Corruption)) then return "corruption opener"; end
   end
   -- drain_soul,if=active_enemies<3&debuff.shadow_embrace.stack<3
   if S.DrainSoul:IsReady() and (EnemiesCount10ySplash < 3 and Target:DebuffStack(S.ShadowEmbraceDebuff) < 3) then

--- a/HeroRotation_Warlock/Demonology.lua
+++ b/HeroRotation_Warlock/Demonology.lua
@@ -159,7 +159,7 @@ local function TyrantPrep()
   end
   -- nether_portal
   if S.NetherPortal:IsReady() then
-    if HR.Cast(S.NetherPortal, Settings.Demonology.GCDasOffGCD.NetherPortal, nil, not Target:IsSpellInRange(S.NetherPortal)) then return "nether_portal 66"; end
+    if HR.Cast(S.NetherPortal, Settings.Demonology.GCDasOffGCD.NetherPortal, nil, nil) then return "nether_portal 66"; end
   end
   -- grimoire_felguard
   if S.GrimoireFelguard:IsReady() then
@@ -192,15 +192,8 @@ local function TyrantPrep()
 end
 
 local function SummonTyrant()
-  -- for proper display of what spell is next while casting tyrant
-  if Player:IsCasting(S.SummonDemonicTyrant) and S.DemonicStrength:IsCastable() and (S.Felstorm:CooldownRemains() < 30 - (5 * (1 - (Player:HastePct() / 100)))) then
-    if HR.Cast(S.DemonicStrength, Settings.Demonology.GCDasOffGCD.DemonicStrength) then return "demonic_strength post_tyrant"; end
-  end
-  if Player:IsCasting(S.SummonDemonicTyrant) and S.BilescourgeBombers:IsReady() then
-    if HR.Cast(S.BilescourgeBombers, nil, nil, not Target:IsSpellInRange(S.BilescourgeBombers)) then return "bilescourge_bombers post_tyrant"; end
-  end
-  -- Moved from lower in the function so we abort this function right after using Demonic Tyrant
-  if (not S.SummonDemonicTyrant:CooldownUp()) then
+-- Moved from lower in the function so we abort this function right after using Demonic Tyrant
+  if (not S.SummonDemonicTyrant:CooldownUp() or Player:BuffRemains(S.NetherPortalBuff) > 4) then
     VarTyrantReady = false
   end
   -- hand_of_guldan,if=soul_shard=5,line_cd=20


### PR DESCRIPTION
Changes for Smoother Nether Portal Gameplay:
- Removing range from HR.Cast that way Nether Portal doesn't always appear red within HR.  Range calculation for things like Nether Portal and Vilefiend isn't really needed as you can use these spells regardless if you have a target or not.
- Adding check within SummonTyrant() function to see if Nether Portal Buff is up.  The reason I set it > 4 is because you don't want it to kick you back if it were just about to finish because you would lose out on the initial demons spawned by Nether Portal.  The reason I added this was often when you are playing, you wait to deploy your Nether Portal for an opportune time.  While waiting, it's extremely likely that VarTyrantReady has been set to true.  When the time window opens to use Nether Portal and you drop it, the APL will never utilize the full benefits of Nether Portal if VarTyrantReady was set to true.  All the Nether Portal logic exists in TyrantPrep().  After this change, this feels fantastic with Nether Portal now properly creating tons of demons before Tyrant is dropped.

Cleanup:
- I added two lines on my past merge that after playing with for a while I feel just aren't needed.  They weren't in the original APL and were added as minor convenience, however I am removing them due to their incompatibility if you are running Doom as a talent.  