### PR TITLE
(Demonology) Adding implosion setting back and proper display of Demonic Strength and Bilescourge Bombers when casting Tyrant

### DIFF
--- a/HeroRotation_Warlock/Demonology.lua
+++ b/HeroRotation_Warlock/Demonology.lua
@@ -188,7 +188,14 @@ local function TyrantPrep()
 end
 
 local function SummonTyrant()
--- Moved from lower in the function so we abort this function right after using Demonic Tyrant
+  -- for proper display of what spell is next while casting tyrant
+  if Player:IsCasting(S.SummonDemonicTyrant) and S.DemonicStrength:IsCastable() and (S.Felstorm:CooldownRemains() < 30 - (5 * (1 - (Player:HastePct() / 100)))) then
+    if HR.Cast(S.DemonicStrength, Settings.Demonology.GCDasOffGCD.DemonicStrength) then return "demonic_strength summon_tyrant"; end
+  end
+  if Player:IsCasting(S.SummonDemonicTyrant) and S.BilescourgeBombers:IsReady() then
+    if HR.Cast(S.BilescourgeBombers, nil, nil, not Target:IsInRange(40)) then return "bilescourge_bombers summon_tyrant"; end
+  end
+  -- Moved from lower in the function so we abort this function right after using Demonic Tyrant
   if (not S.SummonDemonicTyrant:CooldownUp() or Player:BuffRemains(S.NetherPortalBuff) > 4) then
     VarTyrantReady = false
   end
@@ -349,11 +356,11 @@ local function APL()
       if HR.Cast(S.BilescourgeBombers, nil, nil, not Target:IsInRange(40)) then return "bilescourge_bombers 30"; end
     end
     -- implosion,if=active_enemies>1&!talent.sacrificed_souls.enabled&buff.wild_imps.stack>=6&buff.tyrant.down&cooldown.summon_demonic_tyrant.remains>5
-    if AoEON() and S.Implosion:IsReady() and (EnemiesCount8ySplash > 1 and not S.SacrificedSouls:IsAvailable() and WildImpsCount() >= 6 and DemonicTyrantTime() == 0 and S.SummonDemonicTyrant:CooldownRemains() > 5) then
+    if AoEON() and S.Implosion:IsReady() and (EnemiesCount8ySplash > 1 and not S.SacrificedSouls:IsAvailable() and WildImpsCount() >= Settings.Demonology.ImpsRequiredForImplosion and DemonicTyrantTime() == 0 and S.SummonDemonicTyrant:CooldownRemains() > 5) then
       if HR.Cast(S.Implosion, Settings.Demonology.GCDasOffGCD.Implosion, nil, not Target:IsInRange(40)) then return "implosion 31"; end
     end
     -- implosion,if=active_enemies>2&buff.wild_imps.stack>=6&buff.tyrant.down
-    if AoEON() and S.Implosion:IsReady() and (EnemiesCount8ySplash > 2 and WildImpsCount() >= 6 and DemonicTyrantTime() == 0) then
+    if AoEON() and S.Implosion:IsReady() and (EnemiesCount8ySplash > 2 and WildImpsCount() >= Settings.Demonology.ImpsRequiredForImplosion and DemonicTyrantTime() == 0) then
       if HR.Cast(S.Implosion, Settings.Demonology.GCDasOffGCD.Implosion, nil, not Target:IsInRange(40)) then return "implosion 32"; end
     end
     -- hand_of_guldan,if=soul_shard=5|buff.nether_portal.up

--- a/HeroRotation_Warlock/Settings.lua
+++ b/HeroRotation_Warlock/Settings.lua
@@ -59,7 +59,7 @@ HR.GUISettings.APL.Warlock = {
     }
   },]]
   Demonology = {
-    ImpsRequiredForImplosion = 8,
+    ImpsRequiredForImplosion = 6,
     UnendingResolveHP = 20,
     -- {Display GCD as OffGCD, ForceReturn}
     GCDasOffGCD = {
@@ -114,7 +114,7 @@ CreatePanelOption("Dropdown", CP_Destruction, "APL.Warlock.Destruction.SpellType
 CreateARPanelOptions(CP_Destruction, "APL.Warlock.Destruction")]]
 
 -- Demonology
-CreatePanelOption("Slider", CP_Demonology, "APL.Warlock.Demonology.ImpsRequiredForImplosion", {3, 12, 1}, "Imps Required for Implosion", "Set the number of Imps required for Implosion.")
+CreatePanelOption("Slider", CP_Demonology, "APL.Warlock.Demonology.ImpsRequiredForImplosion", {3, 9, 1}, "Imps Required for Implosion", "Set the number of Imps required for Implosion.")
 CreatePanelOption("Slider", CP_Demonology, "APL.Warlock.Demonology.UnendingResolveHP", {0, 100, 1}, "Unending Resolve HP", "Set the Unending Resolve HP threshold.")
 CreateARPanelOptions(CP_Demonology, "APL.Warlock.Demonology")
 

--- a/HeroRotation_Warlock/Settings.lua
+++ b/HeroRotation_Warlock/Settings.lua
@@ -59,6 +59,7 @@ HR.GUISettings.APL.Warlock = {
     }
   },]]
   Demonology = {
+    ImpsRequiredForImplosion = 8,
     UnendingResolveHP = 20,
     -- {Display GCD as OffGCD, ForceReturn}
     GCDasOffGCD = {
@@ -113,6 +114,7 @@ CreatePanelOption("Dropdown", CP_Destruction, "APL.Warlock.Destruction.SpellType
 CreateARPanelOptions(CP_Destruction, "APL.Warlock.Destruction")]]
 
 -- Demonology
+CreatePanelOption("Slider", CP_Demonology, "APL.Warlock.Demonology.ImpsRequiredForImplosion", {3, 12, 1}, "Imps Required for Implosion", "Set the number of Imps required for Implosion.")
 CreatePanelOption("Slider", CP_Demonology, "APL.Warlock.Demonology.UnendingResolveHP", {0, 100, 1}, "Unending Resolve HP", "Set the Unending Resolve HP threshold.")
 CreateARPanelOptions(CP_Demonology, "APL.Warlock.Demonology")
 


### PR DESCRIPTION
These are just two quality of life upgrades.  There were merged before and then I removed.  I regret this decision haha.  I find myself using the implosion setting quite a bit depending on my situation.  Implosion setting default set to be 6 as now officially reflected in APL.