### PR TITLE
Use community packager

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 100
+
+      - name: Create Package
+        uses: BigWigsMods/packager@master
+        env:
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
+          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Migrating to the BigWigs community packager; This allows builds to be distributed to multiple repository websites, such as Wago, CurseForge, WoW Interface.
The migration is hyper simple, and a matter of merging this PR, and creating environment secrets :)

Also; you will need to add the following to your `HeroRotation/HeroRotation.toc` file

```
## X-Curse-Project-ID: <id>
## X-Wago-ID: <id>
```

Generate a CF token here: https://wow.curseforge.com/account/api-tokens
Generate a Wago token here: https://addons.wago.io/account/apikeys