### PR TITLE
Update Fire.lua to fix uninitialized var_kindling_reduction errors

### DIFF
--- a/HeroRotation_Mage/Fire.lua
+++ b/HeroRotation_Mage/Fire.lua
@@ -69,7 +69,7 @@ local var_hard_cast_flamestrike
 local var_combustion_flamestrike
 local var_arcane_explosion
 local var_arcane_explosion_mana
-local var_kindling_reduction
+local var_kindling_reduction = 0.4
 local var_skb_duration
 local var_combustion_on_use
 local var_empyreal_ordnance_delay
@@ -269,9 +269,6 @@ local function VarInit ()
   if I.EmpyrealOrdnance:IsEquipped() then
     var_on_use_cutoff = 20 + var_empyreal_ordnance_delay
   end
-
-  --variable,name=kindling_reduction,default=0.4,op=reset
-  var_kindling_reduction = 0.4
 
   var_init = true
 end


### PR DESCRIPTION
control flow appears to be reaching (current) line 329 "var_combustion_ready_time = S.Combustion:CooldownRemains() * var_kindling_reduction" while var_init is still false, resulting in many errors "attempt to perform arithmetic operation on upvalue 'var_kindling_reduction' (a nil value)"

to reproduce, enter combat as fire mage without targeting anything (e.g. facepull)

initializing var_kindling_reduction at declaration since this appears to be a constant