### PR TITLE
Add missing method EvaluateCycleAdaptiveSwarmDown

### DIFF
--- a/HeroRotation_Druid/Restoration.lua
+++ b/HeroRotation_Druid/Restoration.lua
@@ -124,6 +124,10 @@ local function EvaluateCycleAdaptiveSwarmCount4(TargetUnit)
   return (TargetUnit:DebuffStack(S.AdaptiveSwarmDebuff) == 4 and TargetUnit:DebuffRemains(S.AdaptiveSwarmDebuff) > 2)
 end
 
+local function EvaluateCycleAdaptiveSwarmDown(TargetUnit)
+  return TargetUnit:DebuffStack(S.AdaptiveSwarmDebuff) == 0
+end
+
 local function EvaluateCycleCatSunfire(TargetUnit)
   return (TargetUnit:DebuffRefreshable(S.SunfireDebuff) and FightRemains > 5)
 end


### PR DESCRIPTION
The Restoration Druid profile has a few checks to decide when to cast Adaptive Swarm.  One of the checks references a function that isn't defined.  Ref: https://github.com/herotc/hero-rotation/blob/shadowlands/HeroRotation_Druid/Restoration.lua#L216

This PR implements the missing `EvaluateCycleAdaptiveSwarmDown` method.