### PR TITLE
Update Arms.lua

### DIFF
--- a/HeroRotation_Warrior/Arms.lua
+++ b/HeroRotation_Warrior/Arms.lua
@@ -187,7 +187,7 @@ local function Hac()
     if Cast(S.Overpower, nil, nil, not TargetInMeleeRange) then return "overpower hac 36"; end
   end
   -- whirlwind
-  if S.Whirlwind:IsReady() then
+  if S.Whirlwind:IsReady() and Player:BuffDown(S.SweepingStrikesBuff) and EnemiesCount8y > 2then
     if Cast(S.Whirlwind, nil, nil, not Target:IsInRange(8)) then return "whirlwind hac 38"; end
   end
   


### PR DESCRIPTION
Casting Whirlwind is senseless while sweeping strikes and also not rentable with less than 3 enemies.