### PR TITLE
Fixing Lua error in Frost mage rotation

### DIFF
--- a/HeroRotation_Mage/Frost.lua
+++ b/HeroRotation_Mage/Frost.lua
@@ -151,7 +151,7 @@ end
 
 local function Aoe()
   -- cone_of_cold,if=buff.snowstorm.stack=buff.snowstorm.max_stack&debuff.frozen.up&(prev_gcd.1.frost_nova|prev_gcd.1.ice_nova|prev_off_gcd.freeze)
-  if S.ConeofCold:IsCastable() and (Player:BuffStackP(S.SnowstormBuff) == var_snowstorm_max_stack and FrozenRemains > 0 and (Player:PrevGCDP(1, S.FrostNova) or Player:PrevGCDP(1, S.IceNova) or Player:PrevGCDP(1, S.Freeze))) then
+  if S.ConeofCold:IsCastable() and (Player:BuffStackP(S.SnowstormBuff) == var_snowstorm_max_stack and FrozenRemains() > 0 and (Player:PrevGCDP(1, S.FrostNova) or Player:PrevGCDP(1, S.IceNova) or Player:PrevGCDP(1, S.Freeze))) then
     if Cast(S.ConeofCold, nil, nil, not Target:IsInRange(12)) then return "cone_of_cold aoe 2"; end
   end
   -- frozen_orb
@@ -167,7 +167,7 @@ local function Aoe()
     if Cast(S.CometStorm, nil, nil, not Target:IsSpellInRange(S.CometStorm)) then return "comet_storm aoe 8"; end
   end
   -- freeze,if=(target.level<level+3|target.is_add)&(!talent.snowstorm&debuff.frozen.down|cooldown.cone_of_cold.ready&buff.snowstorm.stack=buff.snowstorm.max_stack)
-  if Pet:IsActive() and S.Freeze:IsReady() and (Target:Level() < Player:Level() + 3 and ((not S.Snowstorm:IsAvailable()) and FrozenRemains == 0 or S.ConeofCold:CooldownUp() and Player:BuffStackP(S.SnowstormBuff) == var_snowstorm_max_stack)) then
+  if Pet:IsActive() and S.Freeze:IsReady() and (Target:Level() < Player:Level() + 3 and ((not S.Snowstorm:IsAvailable()) and FrozenRemains() == 0 or S.ConeofCold:CooldownUp() and Player:BuffStackP(S.SnowstormBuff) == var_snowstorm_max_stack)) then
     if Cast(S.Freeze, nil, nil, not Target:IsSpellInRange(S.Freeze)) then return "freeze aoe 10"; end
   end
   -- ice_nova,if=(target.level<level+3|target.is_add)&(prev_gcd.1.comet_storm|cooldown.cone_of_cold.ready&buff.snowstorm.stack=buff.snowstorm.max_stack&gcd.max<1)


### PR DESCRIPTION
I encountered this bug while testing out the Frost mage AoE rotation on a dummy. You can reproduce it by hitting max stacks of Snowstorm (30), and the sim will get stuck on Cone of Cold.  I'm not a Lua developer but this addressed the issue for me. Seemed like an oversight as the function is called as `FrozenRemains()` later in the script.

```
534x HeroRotation_Mage/Frost.lua:154: attempt to compare number with function
[string "@HeroRotation_Mage/Frost.lua"]:154: in function <HeroRotation_Mage/Frost.lua:152>
[string "@HeroRotation_Mage/Frost.lua"]:343: in function `?'
[string "@HeroRotation/Main.lua"]:455: in function <HeroRotation/Main.lua:433>
```

Full error report:
```
534x HeroRotation_Mage/Frost.lua:154: attempt to compare number with function
[string "@HeroRotation_Mage/Frost.lua"]:154: in function <HeroRotation_Mage/Frost.lua:152>
[string "@HeroRotation_Mage/Frost.lua"]:343: in function `?'
[string "@HeroRotation/Main.lua"]:455: in function <HeroRotation/Main.lua:433>

Locals:
(*temporary) = <function> defined @HeroRotation_Mage/Frost.lua:73
(*temporary) = 30
(*temporary) = <table> {
 LastCastTime = 0
 LastHitTime = 0
 LastAppliedOnPlayerTime = 19366.232000
 LastRemovedFromPlayerTime = 19145.145000
 SpellName = "Snowstorm"
 IsMelee = true
 SpellType = "Player"
 MaximumRange = 0
 MinimumRange = 0
 LastDisplayTime = 0
 SpellID = 381522
}
(*temporary) = nil
(*temporary) = nil
(*temporary) = 30
(*temporary) = <table> {
 LastCastTime = 0
 LastHitTime = 0
 LastAppliedOnPlayerTime = 19408.101000
 LastRemovedFromPlayerTime = 19399.137000
 SpellName = "Fingers of Frost"
 IsMelee = false
 SpellType = "Player"
 MaximumRange = 100
 MinimumRange = 0
 LastDisplayTime = 0
 SpellID = 44544
}
(*temporary) = "attempt to compare number with function"
S = <table> {
 RemoveCurse = <table> {
 }
 Blizzard = <table> {
 }
 RuneofPower = <table> {
 }
 Flurry = <table> {
 }
 FreezingWindsBuff = <table> {
 }
 RingOfFrost = <table> {
 }
 Freeze = <table> {
 }
 BloodFury = <table> {
 }
 BerserkingBuff = <table> {
 }
 FocusMagic = <table> {
 }
 WintersChillDebuff = <table> {
 }
 RayofFrost = <table> {
 }
 Counterspell = <table> {
 }
 SpellSteal = <table> {
 }
 ArcaneExplosion = <table> {
 }
 ArcaneIntellectBuff = <table> {
 }
 BrainFreezeBuff = <table> {
 }
 IceBarrier = <table> {
 }
 IceNova = <table> {
 }
 Meteor = <table> {
 }
 SlickIce = <table> {
 }
 BagofTricks = <table> {
 }
 FireBlast = <table> {
 }
 CometStorm = <table> {
 }
 FrostNova = <table> {
 }
 SlowFall = <table> {
 }
 IceFloes = <table> {
 }
 Invisibility = <table> {
 }
 ArcaneIntellect = <table> {
 }
 TemporalWarpBuff = <table> {
 }
 AncestralCall = <table> {
 }
 LightsJudgment = <table> {
 }
 WaterJet = <table> {
 }
 IciclesBuff = <table> {
 }
 IceCaller = <table> {
 }
 FrozenOrb = <table> {
 }
 Ebonbolt = <table> {
 }
 ShiftingPower = <table> {
 }
 TemporalWarp = <table> {
 }
 Fireblood = <table> {
 }
 FreezingRain = <table> {
 }
 BloodFuryBuff = <table> {
 }
 ConeofCold = <table> {
 }
 Frostbolt = <table> {
 }
 Snowstorm = <table> {
 }
 GlacialSpike = <table> {
 }
 TimeWarp = <table> {
 }
 FreezingRainBuff = <table> {
 }
 IcyVeinsBuff = <table> {
 }
 SnowstormBuff = <table> {
 }
 AlterTime = <table> {
 }
 IceLance = <table> {
 }
 SplittingIce = <table> {
 }
 Frostbite = <table> {
 }
 SummonWaterElemental = <table> {
 }
 ChainReaction = <table> {
 }
 IceBlock = <table> {
 }
 IcyVeins = <table> {
 }
 FingersofFrostBuff = <table> {
 }
 GlacialSpikeBuff = <table> {
 }
 BoneChilling = <table> {
 }
 Blink = <table> {
 }
 DragonsBreath = <table> {
 }
 Berserking = <table> {
 }
 BlastWave = <table> {
 }
 FreezingWinds = <table> {
 }
 RuneofPowerBuff = <table> {
 }
 MirrorImage = <table> {
 }
}
Player = <table> {
 UseCache = true
 ChiDeficitPercentage = <function> defined @HeroLib/Class/Unit/Player/Power.lua:595
 GCDStartTime = <function> defined @HeroLib/Class/Unit/Player/Stat.lua:70
 Race = <function> defined @HeroLib/Class/Unit/Player/Main.lua:45
 Insanityrain = <function> defined @HeroLib/Class/Unit/Player/Power.lua:647
 FocusLossOnCastEnd = <function> defined @HeroLib/Class/Unit/Player/Power.lua:226
 PainMax = <function> defined @HeroLib/Class/Unit/Player/Power.lua:724
 IsInVehicle = <function> defined @HeroLib/Class/Unit/Player/Main.lua:104
 IsInParty = <function> defined @HeroLib/Class/Unit/Player/Main.lua:32
 EnergyDeficit = <function> defined @HeroLib/Class/Unit/Player/Power.lua:279
 Fury = <function> defined @HeroLib/Class/Unit/Player/Power.lua:697
 InstanceInfo = <function> defined @HeroLib/Class/Unit/Player/Instance.lua:22
 RageDeficit = <function> defined @HeroLib/Class/Unit/Player/Power.lua:139
 VersatilityDmgPct = <function> defined @HeroLib/Class/Unit/Player/Stat.lua:119
 ArcaneChargesDeficitPercentage = <function> defined @HeroLib/Class/Unit/Player/Power.lua:680
 MaelstromPercentage = <function
```