### PR TITLE
Rogue updates

### DIFF
--- a/HeroRotation_Rogue/Assassination.lua
+++ b/HeroRotation_Rogue/Assassination.lua
@@ -679,10 +679,11 @@ local function ShivUsage ()
 
     -- # Shiv cases for Kingsbane
     -- actions.shiv+=/shiv,if=!talent.lightweight_shiv.enabled&variable.shiv_kingsbane_condition
-    -- &(dot.kingsbane.ticking&dot.kingsbane.remains<8|cooldown.kingsbane.remains>=24)
+    -- &(dot.kingsbane.ticking&dot.kingsbane.remains<8|!dot.kingsbane.ticking&cooldown.kingsbane.remains>=24)
     -- &(!talent.crimson_tempest.enabled|variable.single_target|dot.crimson_tempest.ticking)
-    if not S.LightweightShiv:IsAvailable() and ShivKingsbaneCondition and (Target:DebuffUp(S.Kingsbane) and Target:DebuffRemains(S.Kingsbane) < 8
-      or S.Kingsbane:CooldownRemains() >= 24) and (not S.CrimsonTempest:IsAvailable() or SingleTarget or Target:DebuffUp(S.CrimsonTempest)) then
+    if not S.LightweightShiv:IsAvailable() and ShivKingsbaneCondition
+      and (Target:DebuffUp(S.Kingsbane) and Target:DebuffRemains(S.Kingsbane) < 8 or not Target:DebuffUp(S.Kingsbane) and S.Kingsbane:CooldownRemains() >= 24)
+      and (not S.CrimsonTempest:IsAvailable() or SingleTarget or Target:DebuffUp(S.CrimsonTempest)) then
       if Cast(S.Shiv, Settings.Assassination.GCDasOffGCD.Shiv) then
         return "Cast Shiv (Kingsbane)"
       end

--- a/HeroRotation_Rogue/Assassination.lua
+++ b/HeroRotation_Rogue/Assassination.lua
@@ -58,6 +58,7 @@ local I = Item.Rogue.Assassination
 local OnUseExcludeTrinkets = {
   I.AlgetharPuzzleBox:ID(),
   I.AshesoftheEmbersoul:ID(),
+  I.BottledFlayedwingToxin:ID(),
   I.ImperfectAscendancySerum:ID(),
   I.TreacherousTransmitter:ID(),
 }
@@ -1112,6 +1113,13 @@ local function APL ()
 
   -- Poisons
   Rogue.Poisons()
+
+  -- Bottled Flayedwing Toxin
+  if I.BottledFlayedwingToxin:IsEquippedAndReady() and Player:BuffDown(S.FlayedwingToxin) then
+    if Cast(I.BottledFlayedwingToxin, nil, Settings.CommonsDS.DisplayStyle.Trinkets) then
+      return "Bottled Flayedwing Toxin";
+    end
+  end
 
   -- Out of Combat
   if not Player:AffectingCombat() then

--- a/HeroRotation_Rogue/Outlaw.lua
+++ b/HeroRotation_Rogue/Outlaw.lua
@@ -53,6 +53,7 @@ local I = Item.Rogue.Outlaw
 
 -- Create table to exclude above trinkets from On Use function
 local OnUseExcludes = {
+  I.BottledFlayedwingToxin:ID(),
   I.ImperfectAscendancySerum:ID(),
   I.MadQueensMandate:ID()
 }
@@ -838,6 +839,13 @@ local function APL ()
 
   -- Poisons
   Rogue.Poisons()
+
+  -- Bottled Flayedwing Toxin
+  if I.BottledFlayedwingToxin:IsEquippedAndReady() and Player:BuffDown(S.FlayedwingToxin) then
+    if Cast(I.BottledFlayedwingToxin, nil, Settings.CommonsDS.DisplayStyle.Trinkets) then
+      return "Bottled Flayedwing Toxin";
+    end
+  end
 
   -- Out of Combat
   if not Player:AffectingCombat() and S.Vanish:TimeSinceLastCast() > 1 then

--- a/HeroRotation_Rogue/Outlaw.lua
+++ b/HeroRotation_Rogue/Outlaw.lua
@@ -448,7 +448,7 @@ local function SpellQueueMacro (BaseSpell, ReturnSpellOnly)
     if not Player:StealthUp(true, true) then
       local MacroAbilities = StealthCDs(true)
       -- Make sure StealthCDs returned a combo which may not happen if targeting something out of range
-      if MacroAbilities and MacroAbilities[2] and MacroAbilities[2] ~= "Cast Vanish" then
+      if MacroAbilities and MacroAbilities[2] and MacroAbilities[2] ~= "Cast Vanish" and MacroAbilities[3] then
         local ARMacroTable = { BaseSpell, unpack(MacroAbilities) }
         ShouldReturn = CastQueue(unpack(ARMacroTable))
         if ShouldReturn then

--- a/HeroRotation_Rogue/Outlaw.lua
+++ b/HeroRotation_Rogue/Outlaw.lua
@@ -462,7 +462,7 @@ local function SpellQueueMacro (BaseSpell, ReturnSpellOnly)
       if not Player:StealthUp(true, true) then
         local MacroAbilities = StealthCDs(true)
         -- Make sure StealthCDs returned a combo which may not happen if targeting something out of range
-        if MacroAbilities and MacroAbilities[2] and MacroAbilities[2] ~= "Cast Vanish" and MacroAbilities[3] then
+        if MacroAbilities and MacroAbilities[2] and MacroAbilities[2] ~= "Cast Vanish" then
           local ARMacroTable = { BaseSpell, unpack(MacroAbilities) }
           ShouldReturn = CastQueue(unpack(ARMacroTable))
           if ShouldReturn then

--- a/HeroRotation_Rogue/Outlaw.lua
+++ b/HeroRotation_Rogue/Outlaw.lua
@@ -273,30 +273,30 @@ local function Stealth(ReturnSpellOnly)
   end
 
   -- actions.stealth+=/cold_blood,if=variable.finish_condition
-  if S.ColdBlood:IsCastable() and Player:BuffDown(S.ColdBlood) and Target:IsSpellInRange(S.Dispatch) and Finish_Condition() then
+  if S.ColdBlood:IsCastable() and Player:BuffDown(S.ColdBlood) and Finish_Condition() then
     if Cast(S.ColdBlood, Settings.CommonsOGCD.OffGCDasOffGCD.ColdBlood) then
       return "Cast Cold Blood"
     end
   end
 
   -- actions.stealth+=/between_the_eyes,if=variable.finish_condition&talent.crackshot&(!buff.shadowmeld.up|stealthed.rogue)
-  if S.BetweentheEyes:IsCastable() and Target:IsSpellInRange(S.BetweentheEyes) and Finish_Condition() and S.Crackshot:IsAvailable()
+  if S.BetweentheEyes:IsCastable() and Finish_Condition() and S.Crackshot:IsAvailable()
     and (not Player:BuffUp(S.Shadowmeld) or Player:StealthUp(true, false)) then
     if ReturnSpellOnly then
       return S.BetweentheEyes
     else
-      if CastPooling(S.BetweentheEyes) then
+      if CastPooling(S.BetweentheEyes, nil, not Target:IsSpellInRange(S.BetweentheEyes)) then
         return "Cast Between the Eyes"
       end
     end
   end
 
   -- actions.stealth+=/dispatch,if=variable.finish_condition
-  if S.Dispatch:IsCastable() and Target:IsSpellInRange(S.Dispatch) and Finish_Condition() then
+  if S.Dispatch:IsCastable() and Finish_Condition() then
     if ReturnSpellOnly then
       return S.Dispatch
     else
-      if CastPooling(S.Dispatch) then
+      if CastPooling(S.Dispatch, nil, not Target:IsSpellInRange(S.Dispatch)) then
         return "Cast Dispatch"
       end
     end
@@ -305,12 +305,12 @@ local function Stealth(ReturnSpellOnly)
   -- # 2 Fan the Hammer Crackshot builds can consume Opportunity in stealth with max stacks, Broadside, and low CPs, or with Greenskins active
   -- actions.stealth+=/pistol_shot,if=talent.crackshot&talent.fan_the_hammer.rank>=2&buff.opportunity.stack>=6
   -- &(buff.broadside.up&combo_points<=1|buff.greenskins_wickers.up)
-  if S.PistolShot:IsCastable() and Target:IsSpellInRange(S.PistolShot) and S.Crackshot:IsAvailable() and S.FanTheHammer:TalentRank() >= 2 and Player:BuffStack(S.Opportunity) >= 6
+  if S.PistolShot:IsCastable() and S.Crackshot:IsAvailable() and S.FanTheHammer:TalentRank() >= 2 and Player:BuffStack(S.Opportunity) >= 6
     and (Player:BuffUp(S.Broadside) and ComboPoints <= 1 or Player:BuffUp(S.GreenskinsWickersBuff)) then
     if ReturnSpellOnly then
       return S.PistolShot
     else
-      if CastPooling(S.PistolShot) then
+      if CastPooling(S.PistolShot, nil, not Target:IsSpellInRange(S.PistolShot)) then
         return "Cast Pistol Shot"
       end
     end
@@ -328,11 +328,11 @@ local function Stealth(ReturnSpellOnly)
   end
 
   -- actions.stealth+=/ambush,if=talent.hidden_opportunity
-  if S.Ambush:IsCastable() and Target:IsSpellInRange(S.Ambush) and S.HiddenOpportunity:IsAvailable() then
+  if S.Ambush:IsCastable() and S.HiddenOpportunity:IsAvailable() then
     if ReturnSpellOnly then
       return S.Ambush
     else
-      if CastPooling(S.Ambush) then
+      if CastPooling(S.Ambush, nil, not Target:IsSpellInRange(S.Ambush)) then
         return "Cast Ambush"
       end
     end
@@ -344,13 +344,13 @@ local function Finish(ReturnSpellOnly)
   -- actions.finish=between_the_eyes,if=!talent.crackshot
   -- &(buff.between_the_eyes.remains<4|talent.improved_between_the_eyes|talent.greenskins_wickers)
   -- &!buff.greenskins_wickers.up
-  if S.BetweentheEyes:IsCastable() and Target:IsSpellInRange(S.BetweentheEyes) and not S.Crackshot:IsAvailable()
+  if S.BetweentheEyes:IsCastable() and not S.Crackshot:IsAvailable()
     and (Player:BuffRemains(S.BetweentheEyes) < 4 or S.ImprovedBetweenTheEyes:IsAvailable() or S.GreenskinsWickers:IsAvailable())
     and Player:BuffDown(S.GreenskinsWickers) then
     if ReturnSpellOnly then
       return S.BetweentheEyes
     else
-      if CastPooling(S.BetweentheEyes) then
+      if CastPooling(S.BetweentheEyes, nil, not Target:IsSpellInRange(S.BetweentheEyes)) then
         return "Cast Between the Eyes"
       end
     end
@@ -361,11 +361,11 @@ local function Finish(ReturnSpellOnly)
   -- actions.finish+=/between_the_eyes,if=talent.crackshot&(cooldown.vanish.remains>45|talent.underhanded_upper_hand
   -- &talent.without_a_trace&(buff.adrenaline_rush.remains>12|buff.adrenaline_rush.down&cooldown.adrenaline_rush.remains>45))
   -- &(raid_event.adds.remains>8|raid_event.adds.in<raid_event.adds.remains|!raid_event.adds.up)
-  if S.BetweentheEyes:IsCastable() and Target:IsSpellInRange(S.BetweentheEyes) and Settings.Outlaw.UseBtEOutsideOfStealth then
+  if S.BetweentheEyes:IsCastable() and Settings.Outlaw.UseBtEOutsideOfStealth then
     if S.Crackshot:IsAvailable() and (S.Vanish:CooldownRemains() > 45 or S.UnderhandedUpperhand:IsAvailable()
       and S.WithoutATrace:IsAvailable() and (Player:BuffRemains(S.AdrenalineRush) > 12 or Player:BuffDown(S.AdrenalineRush)
       and S.AdrenalineRush:CooldownRemains() > 45)) and (HL.FilteredFightRemains(EnemiesBF, ">", 30)) then
-      if CastPooling(S.BetweentheEyes) then
+      if CastPooling(S.BetweentheEyes, nil, not Target:IsSpellInRange(S.BetweentheEyes)) then
         return "Cast Between the Eyes"
       end
     end
@@ -378,35 +378,35 @@ local function Finish(ReturnSpellOnly)
     if ReturnSpellOnly then
       return S.SliceandDice
     else
-      if CastPooling(S.SliceandDice) then
+      if Cast(S.SliceandDice) then
         return "Cast Slice and Dice"
       end
     end
   end
 
-  if S.ColdBlood:IsCastable() and Player:BuffDown(S.ColdBlood) and Target:IsSpellInRange(S.Dispatch) then
+  if S.ColdBlood:IsCastable() and Player:BuffDown(S.ColdBlood) then
     if Cast(S.ColdBlood, Settings.CommonsOGCD.OffGCDasOffGCD.ColdBlood) then
       return "Cast Cold Blood"
     end
   end
 
   -- actions.finish+=/coup_de_grace
-  if S.CoupDeGrace:IsCastable() and Target:IsSpellInRange(S.CoupDeGrace) then
+  if S.CoupDeGrace:IsCastable() then
     if ReturnSpellOnly then
       return S.CoupDeGrace
     else
-      if CastPooling(S.CoupDeGrace) then
+      if CastPooling(S.CoupDeGrace, nil, not Target:IsSpellInRange(S.CoupDeGrace)) then
         return "Cast Coup de Grace"
       end
     end
   end
 
   -- actions.finish+=/dispatch
-  if S.Dispatch:IsCastable() and Target:IsSpellInRange(S.Dispatch) then
+  if S.Dispatch:IsCastable() then
     if ReturnSpellOnly then
       return S.Dispatch
     else
-      if CastPooling(S.Dispatch) then
+      if CastPooling(S.Dispatch, nil, not Target:IsSpellInRange(S.Dispatch)) then
         return "Cast Dispatch"
       end
     end
@@ -677,7 +677,7 @@ local function CDs ()
   end
 
   -- actions.finish+=/killing_spree,if=variable.finish_condition&!stealthed.all
-  if S.KillingSpree:IsCastable() and Target:IsSpellInRange(S.KillingSpree) and Finish_Condition() and not Player:StealthUp(true, true) then
+  if S.KillingSpree:IsCastable() and Finish_Condition() and not Player:StealthUp(true, true) then
     if Cast(S.KillingSpree, nil, Settings.Outlaw.KillingSpreeDisplayStyle, not Target:IsSpellInRange(S.KillingSpree), nil) then
       return "Cast Killing Spree"
     end
@@ -816,7 +816,7 @@ local function Build ()
   end
 
   -- actions.build+=/sinister_strike
-  if S.SinisterStrike:IsCastable() and Target:IsSpellInRange(S.SinisterStrike) then
+  if S.SinisterStrike:IsCastable() then
     if CastPooling(S.SinisterStrike, nil, not Target:IsSpellInRange(S.SinisterStrike)) then
       return "Cast Sinister Strike"
     end
@@ -906,7 +906,7 @@ local function APL ()
       end
       -- actions.precombat+=/slice_and_dice,precombat_seconds=1
       if S.SliceandDice:IsReady() and Player:BuffRemains(S.SliceandDice) < (1 + ComboPoints) * 1.8 then
-        if CastPooling(S.SliceandDice) then
+        if Cast(S.SliceandDice) then
           return "Cast Slice and Dice (Opener)"
         end
       end

--- a/HeroRotation_Rogue/Outlaw.lua
+++ b/HeroRotation_Rogue/Outlaw.lua
@@ -446,8 +446,8 @@ local function SpellQueueMacro (BaseSpell, ReturnSpellOnly)
     -- Outside of stealth could be AR -> Vanish -> BtE so check for this first then fallback into normal finisher.
     if not Player:StealthUp(true, true) then
       local MacroAbilities = StealthCDs(true)
-      -- Make sure the StealthCDs returned a combo which may not happen if targeting something out of range
-      if MacroAbilities and MacroAbilities[2] ~= "Cast Vanish" then
+      -- Make sure StealthCDs returned a combo which may not happen if targeting something out of range
+      if MacroAbilities and MacroAbilities[2] and MacroAbilities[2] ~= "Cast Vanish" then
         local ARMacroTable = { BaseSpell, unpack(MacroAbilities) }
         ShouldReturn = CastQueue(unpack(ARMacroTable))
         if ShouldReturn then

--- a/HeroRotation_Rogue/Rogue.lua
+++ b/HeroRotation_Rogue/Rogue.lua
@@ -61,6 +61,7 @@ Spell.Rogue.Commons = {
   -- Utility
   Blind                   = Spell(2094),
   CheapShot               = Spell(1833),
+  FullMomentum            = Spell(459228),
   Kick                    = Spell(1766),
   KidneyShot              = Spell(408),
   PickPocket              = Spell(921),
@@ -320,7 +321,8 @@ Item.Rogue.Assassination = {
 Item.Rogue.Outlaw = {
   -- Trinkets
   ImperfectAscendancySerum = Item(225654, {13, 14}),
-  MadQueensMandate         = Item(212454, {13, 14})
+  MadQueensMandate         = Item(212454, {13, 14}),
+  ScrollOfMomentum         = Item(226539, {13, 14})
 }
 
 Item.Rogue.Subtlety = {

--- a/HeroRotation_Rogue/Rogue.lua
+++ b/HeroRotation_Rogue/Rogue.lua
@@ -61,6 +61,7 @@ Spell.Rogue.Commons = {
   -- Utility
   Blind                   = Spell(2094),
   CheapShot               = Spell(1833),
+  FlayedwingToxin         = Spell(345545),
   FullMomentum            = Spell(459228),
   Kick                    = Spell(1766),
   KidneyShot              = Spell(408),
@@ -313,6 +314,7 @@ Item.Rogue.Assassination = {
   -- Trinkets
   AlgetharPuzzleBox       = Item(193701, {13, 14}),
   AshesoftheEmbersoul     = Item(207167, {13, 14}),
+  BottledFlayedwingToxin  = Item(178742, {13, 14}),
   WitherbarksBranch       = Item(109999, {13, 14}),
   ImperfectAscendancySerum = Item(225654, {13, 14}),
   TreacherousTransmitter  = Item(221023, {13, 14})
@@ -320,6 +322,7 @@ Item.Rogue.Assassination = {
 
 Item.Rogue.Outlaw = {
   -- Trinkets
+  BottledFlayedwingToxin   = Item(178742, {13, 14}),
   ImperfectAscendancySerum = Item(225654, {13, 14}),
   MadQueensMandate         = Item(212454, {13, 14}),
   ScrollOfMomentum         = Item(226539, {13, 14})
@@ -327,6 +330,7 @@ Item.Rogue.Outlaw = {
 
 Item.Rogue.Subtlety = {
   -- Trinkets
+  BottledFlayedwingToxin  = Item(178742, {13, 14}),
   ImperfectAscendancySerum = Item(225654, {13, 14}),
   TreacherousTransmitter  = Item(221023, {13, 14})
 }

--- a/HeroRotation_Rogue/Settings.lua
+++ b/HeroRotation_Rogue/Settings.lua
@@ -56,6 +56,7 @@ HR.GUISettings.APL.Rogue = {
       Vanish = true,
       ThistleTea = true,
       ColdBlood = true,
+      Sprint = true,
     }
   },
   Assassination = {

--- a/HeroRotation_Rogue/Subtlety.lua
+++ b/HeroRotation_Rogue/Subtlety.lua
@@ -44,6 +44,7 @@ local I = Item.Rogue.Subtlety
 
 -- Create table to exclude above trinkets from On Use function
 local OnUseExcludes = {
+  I.BottledFlayedwingToxin:ID(),
   I.ImperfectAscendancySerum:ID(),
   I.TreacherousTransmitter:ID()
 }
@@ -1052,6 +1053,13 @@ local function APL ()
 
   -- Poisons
   Rogue.Poisons()
+
+  -- Bottled Flayedwing Toxin
+  if I.BottledFlayedwingToxin:IsEquippedAndReady() and Player:BuffDown(S.FlayedwingToxin) then
+    if Cast(I.BottledFlayedwingToxin, nil, Settings.CommonsDS.DisplayStyle.Trinkets) then
+      return "Bottle Of Flayedwing Toxin";
+    end
+  end
 
   --- Out of Combat
   if not Player:AffectingCombat() then

--- a/HeroRotation_Rogue/Subtlety.lua
+++ b/HeroRotation_Rogue/Subtlety.lua
@@ -224,10 +224,11 @@ local function Used_For_Danse(Spell)
 end
 
 local function Secret_Condition()
-  -- actions.finish=variable,name=secret_condition,value=((buff.danse_macabre.stack>=2+!talent.deathstalkers_mark)
-  -- |!talent.danse_macabre|(talent.unseen_blade&buff.shadow_dance.up&buff.escalating_blade.stack>=2))
-  return ((Player:BuffStack(S.DanseMacabreBuff) >= 2 + BoolToInt(not S.DeathStalkersMark:IsAvailable())) or not S.DanseMacabre:IsAvailable()
-    or (S.UnseenBlade:IsAvailable() and Player:BuffUp(S.ShadowDanceBuff) and Player:BuffStack(S.EscalatingBlade) >= 2))
+  -- actions.finish=variable,name=secret_condition,value=((buff.danse_macabre.stack>=3)|!talent.danse_macabre|
+  -- (talent.unseen_blade&buff.shadow_dance.up&(buff.escalating_blade.stack>=2|buff.shadow_blades.up)))
+  return ((Player:BuffStack(S.DanseMacabreBuff) >= 3) or not S.DanseMacabre:IsAvailable()
+    or (S.UnseenBlade:IsAvailable() and Player:BuffUp(S.ShadowDanceBuff)
+    and (Player:BuffStack(S.EscalatingBlade) >= 2 or Player:BuffUp(S.ShadowBlades))))
 end
 
 local function Trinket_Sync_Slot()
@@ -711,43 +712,18 @@ local function CDs ()
     end
   end
 
-  -- actions.cds+=/shadow_dance,if=!buff.shadow_dance.up&fight_remains<=8+talent.subterfuge.enabled
+  -- # Use shadow dance during subterfuge in CDs or if the fight ends in <8s
+  --actions.cds+=/shadow_dance,if=!buff.shadow_dance.up&(talent.invigorating_shadowdust&buff.shadow_blades.up
+  -- &((talent.deathstalkers_mark&buff.subterfuge.up)|(dot.rupture.ticking&variable.snd_condition&talent.unseen_blade)))
+  -- |fight_remains<=8
   if HR.CDsON() and S.ShadowDance:IsAvailable() and MayBurnShadowDance() and S.ShadowDance:IsReady() then
-    if not Player:BuffUp(S.ShadowDanceBuff) and HL.BossFilteredFightRemains("<=", 8 + num(S.Subterfuge:IsAvailable())) then
+    if not Player:BuffUp(S.ShadowDanceBuff) and (S.InvigoratingShadowdust:IsAvailable() and Player:BuffUp(S.ShadowBlades)
+      and ((S.DeathStalkersMark:IsAvailable() and Player:BuffUp(S.Subterfuge))
+      or (Target:DebuffUp(S.Rupture) and SnD_Condition() and S.UnseenBlade:IsAvailable())))
+      or HL.BossFilteredFightRemains("<=", 8) then
       ShouldReturn = StealthMacro(S.ShadowDance, StealthEnergyRequired)
       if ShouldReturn then
-        return "Shadow Dance Macro CDs 1" .. ShouldReturn
-      end
-    end
-  end
-
-  -- actions.cds+=/shadow_dance,if=!buff.shadow_dance.up&talent.invigorating_shadowdust&talent.deathstalkers_mark
-  -- &buff.shadow_blades.up&(buff.subterfuge.up&spell_targets>=4|buff.subterfuge.remains>=3)
-  if HR.CDsON() and S.ShadowDance:IsAvailable() and S.ShadowDance:IsReady() then
-    if Player:BuffDown(S.ShadowDanceBuff) and S.InvigoratingShadowdust:IsAvailable() and S.DeathStalkersMark:IsAvailable()
-      and (Player:BuffUp(S.ShadowBlades) or S.ShadowBlades:IsReady()) and (Player:BuffUp(S.Subterfuge) and MeleeEnemies10yCount >= 4
-      or Player:BuffRemains(S.Subterfuge) >= 3) then
-      ShouldReturn = StealthMacro(S.ShadowDance, StealthEnergyRequired)
-      if ShouldReturn then
-        return "Shadow Dance Macro CDs 2" .. ShouldReturn
-      end
-    end
-  end
-
-  -- actions.cds+=/shadow_dance,if=!buff.shadow_dance.up&talent.unseen_blade&talent.invigorating_shadowdust
-  -- &dot.rupture.ticking&variable.snd_condition&(buff.symbols_of_death.remains>=6&!buff.flagellation_buff.up
-  -- |buff.symbols_of_death.up&buff.shadow_blades.up|buff.shadow_blades.up&!talent.invigorating_shadowdust)
-  -- &(cooldown.secret_technique.remains<10+12*!talent.invigorating_shadowdust|buff.shadow_blades.up)
-  -- &(!talent.the_first_dance|(combo_points.deficit>=7&!buff.shadow_blades.up|buff.shadow_blades.up))
-  if HR.CDsON() and S.ShadowDance:IsAvailable() and S.ShadowDance:IsReady() then
-    if Player:BuffDown(S.ShadowDanceBuff) and S.UnseenBlade:IsAvailable() and S.InvigoratingShadowdust:IsAvailable()
-      and Target:DebuffUp(S.Rupture) and SnD_Condition() and (Player:BuffRemains(S.SymbolsofDeath) >= 6 and Player:BuffDown(S.Flagellation)
-      or Player:BuffUp(S.SymbolsofDeath) and (Player:BuffUp(S.ShadowBlades) or S.ShadowBlades:IsReady()) or (Player:BuffUp(S.ShadowBlades) or S.ShadowBlades:IsReady()) and not S.InvigoratingShadowdust:IsAvailable())
-      and (S.SecretTechnique:CooldownRemains() <= 10 + 12 * num(not S.InvigoratingShadowdust:IsAvailable() or Player:BuffUp(S.ShadowBlades) or S.ShadowBlades:IsReady())
-      and (not S.TheFirstDance:IsAvailable() or (ComboPointsDeficit >= 7 and Player:BuffDown(S.ShadowBlades) or Player:BuffUp(S.ShadowBlades)))) then
-      ShouldReturn = StealthMacro(S.ShadowDance, StealthEnergyRequired)
-      if ShouldReturn then
-        return "Shadow Dance Macro CDs 3" .. ShouldReturn
+        return "Shadow Dance Macro CDs" .. ShouldReturn
       end
     end
   end
@@ -770,8 +746,7 @@ local function CDs ()
   -- &buff.shadow_blades.up|buff.shadow_dance.remains>=4&cooldown.cold_blood.remains<=3)
   -- |fight_remains<=(6*cooldown.thistle_tea.charges)
   if S.ThistleTea:IsReady() then
-    if Player:BuffDown(S.ThistleTea) and (Player:BuffRemains(S.ShadowDanceBuff) >= 4
-      and Player:BuffUp(S.ShadowBlades) or Player:BuffRemains(S.ShadowDanceBuff) >= 4 and S.ColdBlood:CooldownRemains() <= 3)
+    if Player:BuffDown(S.ThistleTea) and (Player:BuffRemains(S.ShadowDanceBuff) >= 6)
       or HL.BossFilteredFightRemains("<=", 6 * S.ThistleTea:Charges()) then
       if Cast(S.ThistleTea, nil, Settings.CommonsDS.DisplayStyle.Trinkets) then
         return "Thistle Tea";


### PR DESCRIPTION
APL Updates for all 3 specs;

Added Triple cast sequence for Outlaw when Improved AR should go straight into Vanish

added bottled flayedwing toxin to excludes and added a suggestion to use it if the poison buff isn't up for all specs;

attempt to fix random ranged errors with stealth combos

Added an Improved AR into RtB cast sequence before checking for Vanish / Finishers for when a reroll should occurs before a crackshot window with loaded dice. Preventing rolls inside crackshot where possible.

Allow the Cast / CastPooling to handle out of range rather than using explicit out of range checks in conditions;
