### PR TITLE
Increase Vampiric Touch Minimum HP Slider for Shadow Priests

### DIFF
--- a/HeroRotation_Priest/Settings.lua
+++ b/HeroRotation_Priest/Settings.lua
@@ -119,7 +119,7 @@ CreateARPanelOptions(CP_PriestOGCD, "APL.Priest.CommonsOGCD")
 -- Shadow
 CreatePanelOption("Slider", CP_Shadow, "APL.Priest.Shadow.DesperatePrayerHP", { 0, 100, 1 }, "Desperate Prayer HP", "Set the Desperate Prayer HP threshold.")
 CreatePanelOption("Slider", CP_Shadow, "APL.Priest.Shadow.DispersionHP", { 0, 100, 1 }, "Dispersion HP", "Set the Dispersion HP threshold.")
-CreatePanelOption("Slider", CP_Shadow, "APL.Priest.Shadow.VTMinHP", { 0, 20, 1 }, "Minimum VT HP (in millions)", "Set the minimum HP of a target for Vampiric Touch to be suggested. This value is multiplied by 1,000,000. For example, a value of 10 checks for a target's minimum HP of 10,000,000.")
+CreatePanelOption("Slider", CP_Shadow, "APL.Priest.Shadow.VTMinHP", { 0, 100, 1 }, "Minimum VT HP (in millions)", "Set the minimum HP of a target for Vampiric Touch to be suggested. This value is multiplied by 1,000,000. For example, a value of 100 checks for a target's minimum HP of 100,000,000.")
 CreatePanelOption("CheckButton", CP_Shadow, "APL.Priest.Shadow.SelfPI", "Assume Self-Power Infusion", "Assume the player will be using Power Infusion on themselves.")
 CreatePanelOption("CheckButton", CP_Shadow, "APL.Priest.Shadow.PreferVTWhenSTinDungeon", "Prefer VT for dungeon ST", "Prefer to use Vampiric Touch while in single target combat in dungeon content. (Note: This does not apply to raid content.)")
 

--- a/HeroRotation_Priest/Shadow.lua
+++ b/HeroRotation_Priest/Shadow.lua
@@ -297,7 +297,8 @@ local function Precombat()
     if Cast(S.ArcaneTorrent, nil, nil, not Target:IsSpellInRange(S.ArcaneTorrent)) then return "arcane_torrent precombat 6"; end
   end
   -- use_item,name=aberrant_spellforge
-  if Settings.Commons.Enabled.Trinkets and I.AberrantSpellforge:IsEquippedAndReady() then
+  -- Note: Added CDsON() check to enforce trinket usage only when CDs are enabled
+  if Settings.Commons.Enabled.Trinkets and I.AberrantSpellforge:IsEquippedAndReady() and CDsON() then
     if Cast(I.AberrantSpellforge, nil, Settings.CommonsDS.DisplayStyle.Trinkets) then return "aberrant_spellforge precombat 8"; end
   end
   -- shadow_crash,if=raid_event.adds.in>=25&spell_targets.shadow_crash<=8&!fight_style.dungeonslice&(!set_bonus.tier31_4pc|spell_targets.shadow_crash>1)
@@ -351,7 +352,8 @@ local function AoE()
 end
 
 local function Trinkets()
-  if Settings.Commons.Enabled.Trinkets then
+  -- Note: Added CDsON() check to match other cooldown usage patterns
+  if Settings.Commons.Enabled.Trinkets and CDsON() then
     -- use_item,use_off_gcd=1,name=aberrant_spellforge,if=gcd.remains>0&buff.aberrant_spellforge.stack<=4
     if I.AberrantSpellforge:IsEquippedAndReady() and (Player:BuffStack(S.AberrantSpellforgeBuff) <= 4) then
       if Cast(I.AberrantSpellforge, nil, Settings.CommonsDS.DisplayStyle.Trinkets) then return "aberrant_spellforge trinkets 26"; end
@@ -362,11 +364,12 @@ local function Trinkets()
     end
   end
   -- use_items,if=(buff.voidform.up|buff.power_infusion.up|buff.dark_ascension.up|(cooldown.void_eruption.remains>10&trinket.cooldown.duration<=60))|fight_remains<20
+  -- Note: Added CDsON() check for trinkets to match other cooldown usage patterns
   local ItemToUse, ItemSlot, ItemRange = Player:GetUseableItems(OnUseExcludes)
   if ItemToUse and ((Player:BuffUp(S.VoidformBuff) or Player:PowerInfusionUp() or Player:BuffUp(S.DarkAscensionBuff) or (S.VoidEruption:CooldownRemains() > 10 and (ItemToUse:Cooldown() <= 60 or ItemSlot ~= 13 and ItemSlot ~= 14))) or BossFightRemains < 20) then
     local DisplayStyle = Settings.CommonsDS.DisplayStyle.Trinkets
     if ItemSlot ~= 13 and ItemSlot ~= 14 then DisplayStyle = Settings.CommonsDS.DisplayStyle.Items end
-    if ((ItemSlot == 13 or ItemSlot == 14) and Settings.Commons.Enabled.Trinkets) or (ItemSlot ~= 13 and ItemSlot ~= 14 and Settings.Commons.Enabled.Items) then
+    if ((ItemSlot == 13 or ItemSlot == 14) and Settings.Commons.Enabled.Trinkets and CDsON()) or (ItemSlot ~= 13 and ItemSlot ~= 14 and Settings.Commons.Enabled.Items) then
       if Cast(ItemToUse, nil, DisplayStyle, not Target:IsInRange(ItemRange)) then return "Generic use_items for " .. ItemToUse:Name() .. " trinkets 30"; end
     end
   end

--- a/HeroRotation_Priest/Shadow.lua
+++ b/HeroRotation_Priest/Shadow.lua
@@ -542,7 +542,7 @@ local function Main()
     local ShouldReturn = CDs(); if ShouldReturn then return ShouldReturn; end
   end
   -- mindbender,if=(dot.shadow_word_pain.ticking&variable.dots_up|action.shadow_crash.in_flight&talent.whispering_shadows)&(fight_remains<30|target.time_to_die>15)&(!talent.dark_ascension|cooldown.dark_ascension.remains<gcd.max|fight_remains<15)
-  if Fiend:IsCastable() and ((Target:DebuffUp(S.ShadowWordPainDebuff) and VarDotsUp or Crash:InFlight() and S.WhisperingShadows:IsAvailable()) and (BossFightRemains < 30 or Target:TimeToDie() > 15) and (not S.DarkAscension:IsAvailable() or S.DarkAscension:CooldownRemains() < GCDMax or BossFightRemains < 15)) then
+  if CDsON() and Fiend:IsCastable() and ((Target:DebuffUp(S.ShadowWordPainDebuff) and VarDotsUp or Crash:InFlight() and S.WhisperingShadows:IsAvailable()) and (BossFightRemains < 30 or Target:TimeToDie() > 15) and (not S.DarkAscension:IsAvailable() or S.DarkAscension:CooldownRemains() < GCDMax or BossFightRemains < 15)) then
     if Cast(Fiend, Settings.Shadow.GCDasOffGCD.Mindbender) then return "mindbender main 2"; end
   end
   -- void_blast,target_if=max:(dot.devouring_plague.remains*1000+target.time_to_die),if=(dot.devouring_plague.remains>=execute_time|buff.entropic_rift.remains<=gcd.max|action.void_torrent.channeling&talent.void_empowerment)&(insanity.deficit>=16|cooldown.mind_blast.full_recharge_time<=gcd.max)&(!talent.mind_devourer|!buff.mind_devourer.up|buff.entropic_rift.remains<=gcd.max)


### PR DESCRIPTION
Increased the slider range for APL.Priest.Shadow.VTMinHP from { 0, 20, 1 } to { 0, 100, 1 } to accommodate scaling health pools as The War Within expansion progresses.