### PR TITLE
Warrior

### DIFF
--- a/HeroRotation_Warrior/Fury.lua
+++ b/HeroRotation_Warrior/Fury.lua
@@ -160,7 +160,7 @@ local function Precombat()
   -- Manually added: Group Battle Shout check
 
   -- Check if cooldowns are enabled
-  if CDsON() then
+  if CDsON() and Settings.Commons.UseCDsInPrecombat then
     -- Check if the Treacherous Transmitter is equipped and ready
     if I.TreacherousTransmitter:IsEquippedAndReady() then
       if Cast(I.TreacherousTransmitter) then return "use_treacherous_transmitter precombat"; end
@@ -185,7 +185,7 @@ local function Precombat()
   end
   
   -- Check if any trinket is equipped and ready, prioritizing on-use trinkets
-  if CDsON() then
+  if CDsON() and Settings.Commons.UseCDsInPrecombat then
     if Trinket1:IsEquippedAndReady() and not VarTrinket1Manual and Trinket1:ID() ~= I.TreacherousTransmitter:ID() and Trinket1:ID() ~= I.ImperfectAscendancySerum:ID() then
       if Trinket1:HasUseBuff() or not Trinket2:HasUseBuff() then
         if Cast(Trinket1) then return "use_trinket_1 precombat"; end
@@ -604,19 +604,19 @@ local function Trinkets()
       if Cast(I.TreacherousTransmitter, nil, Settings.CommonsDS.DisplayStyle.Trinkets) then return "treacherous_transmitter trinkets 2"; end
     end
     -- use_item,slot=trinket1,if=variable.trinket_1_buffs&!variable.trinket_1_manual&(!buff.avatar.up&trinket.1.cast_time>0|!trinket.1.cast_time>0)&((talent.titans_torment&cooldown.avatar.ready)|(buff.avatar.up&!talent.titans_torment))&(variable.trinket_2_exclude|!trinket.2.has_cooldown|trinket.2.cooldown.remains|variable.trinket_priority=1)|trinket.1.proc.any_dps.duration>=fight_remains
-    if Trinket1:IsReady() and not VarTrinket1BL and (VarTrinket1Buffs and not VarTrinket1Manual and (Player:BuffDown(S.AvatarBuff) and VarTrinket1CastTime > 0 or VarTrinket1CastTime == 0) and ((S.TitansTorment:IsAvailable() and S.Avatar:CooldownUp()) or (Player:BuffUp(S.AvatarBuff) and not S.TitansTorment:IsAvailable())) and (VarTrinket2Exclude or not Trinket2:HasCooldown() or Trinket2:CooldownDown() or VarTrinketPriority == 1) or Trinket1:BuffDuration() >= BossFightRemains) then
+    if Trinket1:IsReady() and not VarTrinket1BL and (not Settings.Commons.SyncTrinketsToCDs or (VarTrinket1Buffs and not VarTrinket1Manual and (Player:BuffDown(S.AvatarBuff) and VarTrinket1CastTime > 0 or VarTrinket1CastTime == 0) and ((S.TitansTorment:IsAvailable() and S.Avatar:CooldownUp()) or (Player:BuffUp(S.AvatarBuff) and not S.TitansTorment:IsAvailable())) and (VarTrinket2Exclude or not Trinket2:HasCooldown() or Trinket2:CooldownDown() or VarTrinketPriority == 1) or Trinket1:BuffDuration() >= BossFightRemains)) then
       if Cast(Trinket1, nil, Settings.CommonsDS.DisplayStyle.Trinkets, not Target:IsInRange(VarTrinket1Range)) then return "use_item for " .. Trinket1:Name() .. " trinkets 4"; end
     end
     -- use_item,slot=trinket2,if=variable.trinket_2_buffs&!variable.trinket_2_manual&(!buff.avatar.up&trinket.2.cast_time>0|!trinket.2.cast_time>0)&((talent.titans_torment&cooldown.avatar.ready)|(buff.avatar.up&!talent.titans_torment))&(variable.trinket_1_exclude|!trinket.1.has_cooldown|trinket.1.cooldown.remains|variable.trinket_priority=2)|trinket.2.proc.any_dps.duration>=fight_remains
-    if Trinket2:IsReady() and not VarTrinket2BL and (VarTrinket2Buffs and not VarTrinket2Manual and (Player:BuffDown(S.AvatarBuff) and VarTrinket2CastTime > 0 or VarTrinket2CastTime == 0) and ((S.TitansTorment:IsAvailable() and S.Avatar:CooldownUp()) or (Player:BuffUp(S.AvatarBuff) and not S.TitansTorment:IsAvailable())) and (VarTrinket1Exclude or not Trinket1:HasCooldown() or Trinket1:CooldownDown() or VarTrinketPriority == 2) or Trinket2:BuffDuration() >= BossFightRemains) then
+    if Trinket2:IsReady() and not VarTrinket2BL and (not Settings.Commons.SyncTrinketsToCDs or (VarTrinket2Buffs and not VarTrinket2Manual and (Player:BuffDown(S.AvatarBuff) and VarTrinket2CastTime > 0 or VarTrinket2CastTime == 0) and ((S.TitansTorment:IsAvailable() and S.Avatar:CooldownUp()) or (Player:BuffUp(S.AvatarBuff) and not S.TitansTorment:IsAvailable())) and (VarTrinket1Exclude or not Trinket1:HasCooldown() or Trinket1:CooldownDown() or VarTrinketPriority == 2) or Trinket2:BuffDuration() >= BossFightRemains)) then
       if Cast(Trinket2, nil, Settings.CommonsDS.DisplayStyle.Trinkets, not Target:IsInRange(VarTrinket2Range)) then return "use_item for " .. Trinket2:Name() .. " trinkets 6"; end
     end
     -- use_item,slot=trinket1,if=!variable.trinket_1_buffs&(trinket.1.cast_time>0&!buff.avatar.up|!trinket.1.cast_time>0)&!variable.trinket_1_manual&(!variable.trinket_1_buffs&(trinket.2.cooldown.remains|!variable.trinket_2_buffs)|(trinket.1.cast_time>0&!buff.avatar.up|!trinket.1.cast_time>0)|cooldown.avatar.remains_expected>20)
-    if Trinket1:IsReady() and not VarTrinket1BL and (not VarTrinket1Buffs and (VarTrinket1CastTime > 0 and Player:BuffDown(S.AvatarBuff) or VarTrinket1CastTime == 0) and not VarTrinket1Manual and (not VarTrinket1Buffs and (Trinket2:CooldownDown() or not VarTrinket2Buffs) or (VarTrinket1CastTime > 0 and Player:BuffDown(S.AvatarBuff) or VarTrinket1CastTime == 0) or S.Avatar:CooldownRemains() > 20)) then
+    if Trinket1:IsReady() and not VarTrinket1BL and (not Settings.Commons.SyncTrinketsToCDs or (not VarTrinket1Buffs and (VarTrinket1CastTime > 0 and Player:BuffDown(S.AvatarBuff) or VarTrinket1CastTime == 0) and not VarTrinket1Manual and (not VarTrinket1Buffs and (Trinket2:CooldownDown() or not VarTrinket2Buffs) or (VarTrinket1CastTime > 0 and Player:BuffDown(S.AvatarBuff) or VarTrinket1CastTime == 0) or S.Avatar:CooldownRemains() > 20))) then
       if Cast(Trinket1, nil, Settings.CommonsDS.DisplayStyle.Trinkets, not Target:IsInRange(VarTrinket1Range)) then return "use_item for " .. Trinket1:Name() .. " trinkets 8"; end
     end
     -- use_item,slot=trinket2,if=!variable.trinket_2_buffs&(trinket.2.cast_time>0&!buff.avatar.up|!trinket.2.cast_time>0)&!variable.trinket_2_manual&(!variable.trinket_2_buffs&(trinket.1.cooldown.remains|!variable.trinket_1_buffs)|(trinket.2.cast_time>0&!buff.avatar.up|!trinket.2.cast_time>0)|cooldown.avatar.remains_expected>20)
-    if Trinket2:IsReady() and not VarTrinket2BL and (not VarTrinket2Buffs and (VarTrinket2CastTime > 0 and Player:BuffDown(S.AvatarBuff) or VarTrinket2CastTime == 0) and not VarTrinket2Manual and (not VarTrinket2Buffs and (Trinket1:CooldownDown() or not VarTrinket1Buffs) or (VarTrinket2CastTime > 0 and Player:BuffDown(S.AvatarBuff) or VarTrinket2CastTime == 0) or S.Avatar:CooldownRemains() > 20)) then
+    if Trinket2:IsReady() and not VarTrinket2BL and (not Settings.Commons.SyncTrinketsToCDs or (not VarTrinket2Buffs and (VarTrinket2CastTime > 0 and Player:BuffDown(S.AvatarBuff) or VarTrinket2CastTime == 0) and not VarTrinket2Manual and (not VarTrinket2Buffs and (Trinket1:CooldownDown() or not VarTrinket1Buffs) or (VarTrinket2CastTime > 0 and Player:BuffDown(S.AvatarBuff) or VarTrinket2CastTime == 0) or S.Avatar:CooldownRemains() > 20))) then
       if Cast(Trinket2, nil, Settings.CommonsDS.DisplayStyle.Trinkets, not Target:IsInRange(VarTrinket2Range)) then return "use_item for " .. Trinket2:Name() .. " trinkets 10"; end
     end
   end

--- a/HeroRotation_Warrior/Fury.lua
+++ b/HeroRotation_Warrior/Fury.lua
@@ -15,7 +15,7 @@ local Item       = HL.Item
 -- HeroRotation
 local HR         = HeroRotation
 local Cast       = HR.Cast
-local AoEON      = HR.AOEON
+local AoEON      = HR.AoEON
 local CDsON      = HR.CDsON
 -- Num/Bool Helper Functions
 local num        = HR.Commons.Everyone.num

--- a/HeroRotation_Warrior/Fury.lua
+++ b/HeroRotation_Warrior/Fury.lua
@@ -38,13 +38,7 @@ local OnUseExcludes = {
 
 --- ===== GUI Settings =====
 local Everyone = HR.Commons.Everyone
-local Settings = {
-  General = HR.GUISettings.General,
-  Commons = HR.GUISettings.APL.Warrior.Commons,
-  CommonsDS = HR.GUISettings.APL.Warrior.CommonsDS,
-  CommonsOGCD = HR.GUISettings.APL.Warrior.CommonsOGCD,
-  Fury = HR.GUISettings.APL.Warrior.Fury
-}
+local Settings = HR.GUISettings.APL.Warrior
 
 --- ===== Rotation Variables =====
 local VarSTPlanning, VarAddsRemain
@@ -143,21 +137,30 @@ end, "PLAYER_EQUIPMENT_CHANGED", "SPELLS_CHANGED", "LEARNED_SPELL_IN_TAB")
 
 --- ===== Rotation Functions =====
 local function Precombat()
-  -- flask
-  -- food
-  -- augmentation
-  -- snapshot_stats
-  -- variable,name=trinket_1_exclude,value=trinket.1.is.treacherous_transmitter
-  -- variable,name=trinket_2_exclude,value=trinket.2.is.treacherous_transmitter
-  -- variable,name=trinket_1_sync,op=setif,value=1,value_else=0.5,condition=trinket.1.has_use_buff&(trinket.1.cooldown.duration%%cooldown.avatar.duration=0|trinket.1.cooldown.duration%%cooldown.odyns_fury.duration=0)
-  -- variable,name=trinket_2_sync,op=setif,value=1,value_else=0.5,condition=trinket.2.has_use_buff&(trinket.2.cooldown.duration%%cooldown.avatar.duration=0|trinket.2.cooldown.duration%%cooldown.odyns_fury.duration=0)
-  -- variable,name=trinket_1_buffs,value=trinket.1.has_use_buff|(trinket.1.has_stat.any_dps&!variable.trinket_1_exclude)
-  -- variable,name=trinket_2_buffs,value=trinket.2.has_use_buff|(trinket.2.has_stat.any_dps&!variable.trinket_2_exclude)
-  -- variable,name=trinket_priority,op=setif,value=2,value_else=1,condition=!variable.trinket_1_buffs&variable.trinket_2_buffs|variable.trinket_2_buffs&((trinket.2.cooldown.duration%trinket.2.proc.any_dps.duration)*(1.5+trinket.2.has_buff.strength)*(variable.trinket_2_sync))>((trinket.1.cooldown.duration%trinket.1.proc.any_dps.duration)*(1.5+trinket.1.has_buff.strength)*(variable.trinket_1_sync))
-  -- variable,name=trinket_1_manual,value=trinket.1.is.algethar_puzzle_box
-  -- variable,name=trinket_2_manual,value=trinket.2.is.algethar_puzzle_box
-  -- Note: Moved the above variables to declarations and PLAYER_EQUIPMENT_CHANGED.
-  -- Manually added: Group Battle Shout check
+  -- Use Treacherous Transmitter at the start of precombat if enabled
+  if Settings.Commons["Sync Trinkets with CD Toggle for PreCombat"].UseTreacherousTransmitter then
+    if I.TreacherousTransmitter:IsEquippedAndReady() then
+      if Cast(I.TreacherousTransmitter) then return "use_treacherous_transmitter precombat"; end
+    end
+  end
+
+  -- Use other trinkets before combat if enabled
+  if Settings.Commons["Sync Trinkets with CD Toggle for PreCombat"].UseTrinkets then
+    if I.ImperfectAscendancySerum:IsEquippedAndReady() then
+      if Cast(I.ImperfectAscendancySerum) then return "use_imperfect_ascendancy_serum precombat"; end
+    end
+    -- Add logic for other trinkets here
+  end
+
+  -- Sync cooldowns before combat if enabled
+  if Settings.Commons["Sync Trinkets with CD Toggle for PreCombat"].SyncCooldowns then
+    -- Add logic for syncing cooldowns precombat
+    -- For example:
+    if S.Recklessness:IsCastable() and S.Avatar:IsCastable() then
+      if Cast(S.Recklessness) then return "recklessness precombat sync"; end
+      if Cast(S.Avatar) then return "avatar precombat sync"; end
+    end
+  end
 
   -- Check if cooldowns are enabled
   if CDsON() then

--- a/HeroRotation_Warrior/Fury.lua
+++ b/HeroRotation_Warrior/Fury.lua
@@ -15,7 +15,7 @@ local Item       = HL.Item
 -- HeroRotation
 local HR         = HeroRotation
 local Cast       = HR.Cast
-local AoEON      = HR.AOEON
+local AoEON      = HR.AoEON
 local CDsON      = HR.CDsON
 -- Num/Bool Helper Functions
 local num        = HR.Commons.Everyone.num
@@ -241,77 +241,73 @@ local function SlayerST()
   if S.Rampage:IsReady() and (S.Bladestorm:IsLearned() and S.Bladestorm:CooldownRemains() <= Player:GCD() and Target:DebuffDown(S.ChampionsMightDebuff)) then
     if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_st 14"; end
   end
-  -- rampage,if=talent.anger_management&(rage>=80|cooldown.recklessness.remains<=gcd)
-  if S.Rampage:IsReady() and (S.AngerManagement:IsAvailable() and (Player:Rage() >= 80 or S.Recklessness:CooldownRemains() <= Player:GCD())) then
-    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_st 16"; end 
-  end
-  -- rampage,if=talent.reckless_abandon&(rage>=90|cooldown.recklessness.remains<=gcd)
-  if S.Rampage:IsReady() and (S.RecklessAbandon:IsAvailable() and (Player:Rage() >= 90 or S.Recklessness:CooldownRemains() <= Player:GCD())) then
-    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_st 18"; end
-  end
-  -- rampage,if=!talent.reckless_abandon&!talent.anger_management&rage>=85
-  if S.Rampage:IsReady() and (not S.RecklessAbandon:IsAvailable() and not S.AngerManagement:IsAvailable() and Player:Rage() >= 85) then
-    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_st 20"; end
-  end
   -- bladestorm,if=buff.enrage.up&cooldown.avatar.remains>=9
   if CDsON() and S.Bladestorm:IsCastable() and (EnrageUp and S.Avatar:CooldownRemains() >= 9) then
-    if Cast(S.Bladestorm, Settings.CommonsOGCD.GCDasOffGCD.Bladestorm, nil, not TargetInMeleeRange) then return "bladestorm slayer_st 22"; end
+    if Cast(S.Bladestorm, Settings.CommonsOGCD.GCDasOffGCD.Bladestorm, nil, not TargetInMeleeRange) then return "bladestorm slayer_st 16"; end
   end
   -- onslaught,if=talent.tenderize&buff.brutal_finish.up
   if S.Onslaught:IsReady() and (S.Tenderize:IsAvailable() or Player:BuffUp(S.BrutalFinishBuff)) then
-    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_st 24"; end
+    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_st 18"; end
+  end
+  -- rampage,if=talent.anger_management
+  if S.Rampage:IsReady() and (S.AngerManagement:IsAvailable()) then
+    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_st 20"; end
   end
   -- crushing_blow
   if S.CrushingBlow:IsCastable() then
-    if Cast(S.CrushingBlow, nil, nil, not TargetInMeleeRange) then return "crushing_blow slayer_st 26"; end
+    if Cast(S.CrushingBlow, nil, nil, not TargetInMeleeRange) then return "crushing_blow slayer_st 22"; end
   end
   -- onslaught,if=talent.tenderize
   if S.Onslaught:IsReady() and (S.Tenderize:IsAvailable()) then
-    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_st 28"; end
+    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_st 24"; end
   end
   -- bloodbath,if=rage<100|target.health.pct<35&talent.vicious_contempt
   if S.Bloodbath:IsCastable() and (Player:Rage() < 100 or Target:HealthPercentage() < 35 and S.ViciousContempt:IsAvailable()) then
-    if Cast(S.Bloodbath, nil, nil, not TargetInMeleeRange) then return "bloodbath slayer_st 30"; end
+    if Cast(S.Bloodbath, nil, nil, not TargetInMeleeRange) then return "bloodbath slayer_st 26"; end
   end
   -- raging_blow,if=rage<100&!buff.opportunist.up
   if S.RagingBlow:IsCastable() and (Player:Rage() < 100 and Player:BuffDown(S.OpportunistBuff)) then
-    if Cast(S.RagingBlow, nil, nil, not TargetInMeleeRange) then return "raging_blow slayer_st 32"; end
+    if Cast(S.RagingBlow, nil, nil, not TargetInMeleeRange) then return "raging_blow slayer_st 28"; end
+  end
+  -- rampage,if=talent.reckless_abandon
+  if S.Rampage:IsReady() and (S.RecklessAbandon:IsAvailable()) then
+    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_st 30"; end
   end
   -- execute,if=buff.enrage.up&debuff.marked_for_execution.up
   if S.Execute:IsReady() and (EnrageUp and Target:DebuffUp(S.MarkedforExecutionDebuff)) then
-    if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute slayer_st 34"; end
+    if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute slayer_st 32"; end
   end
   -- bloodthirst,if=!talent.reckless_abandon&buff.enrage.up
   if S.Bloodthirst:IsCastable() and (not S.RecklessAbandon:IsAvailable() and EnrageUp) then
-    if Cast(S.Bloodthirst, nil, nil, not TargetInMeleeRange) then return "bloodthirst slayer_st 36"; end
+    if Cast(S.Bloodthirst, nil, nil, not TargetInMeleeRange) then return "bloodthirst slayer_st 34"; end
   end
   -- raging_blow
   if S.RagingBlow:IsCastable() then
-    if Cast(S.RagingBlow, nil, nil, not TargetInMeleeRange) then return "raging_blow slayer_st 38"; end
+    if Cast(S.RagingBlow, nil, nil, not TargetInMeleeRange) then return "raging_blow slayer_st 36"; end
   end
   -- onslaught
   if S.Onslaught:IsReady() then
-    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_st 40"; end
+    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_st 38"; end
   end
   -- execute
   if S.Execute:IsReady() then
-    if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute slayer_st 42"; end
+    if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute slayer_st 40"; end
   end
   -- bloodthirst
   if S.Bloodthirst:IsCastable() then
-    if Cast(S.Bloodthirst, nil, nil, not TargetInMeleeRange) then return "bloodthirst slayer_st 44"; end
+    if Cast(S.Bloodthirst, nil, nil, not TargetInMeleeRange) then return "bloodthirst slayer_st 42"; end
   end
   -- whirlwind,if=talent.meat_cleaver
   if S.Whirlwind:IsCastable() and (S.MeatCleaver:IsAvailable()) then
-    if Cast(S.Whirlwind, nil, nil, not Target:IsInMeleeRange(8)) then return "whirlwind slayer_st 46"; end
+    if Cast(S.Whirlwind, nil, nil, not Target:IsInMeleeRange(8)) then return "whirlwind slayer_st 44"; end
   end
   -- slam
   if S.Slam:IsCastable() then
-    if Cast(S.Slam, nil, nil, not TargetInMeleeRange) then return "slam slayer_st 48"; end
+    if Cast(S.Slam, nil, nil, not TargetInMeleeRange) then return "slam slayer_st 46"; end
   end
   -- storm_bolt,if=buff.bladestorm.up
   if S.StormBolt:IsCastable() and (Player:BuffUp(S.Bladestorm)) then
-    if Cast(S.StormBolt, nil, nil, not Target:IsInRange(20)) then return "storm_bolt slayer_st 50"; end
+    if Cast(S.StormBolt, nil, nil, not Target:IsInRange(20)) then return "storm_bolt slayer_st 48"; end
   end
 end
 
@@ -348,73 +344,69 @@ local function SlayerMT()
   if S.Rampage:IsReady() and (S.Bladestorm:IsLearned() and S.Bladestorm:CooldownRemains() <= Player:GCD() and Target:DebuffDown(S.ChampionsMightDebuff)) then
     if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_mt 16"; end
   end
-  -- rampage,if=talent.anger_management&(rage>=80|cooldown.recklessness.remains<=gcd)
-  if S.Rampage:IsReady() and (S.AngerManagement:IsAvailable() and (Player:Rage() >= 80 or S.Recklessness:CooldownRemains() <= Player:GCD())) then
-    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_mt 18"; end 
-  end
-  -- rampage,if=talent.reckless_abandon&(rage>=90|cooldown.recklessness.remains<=gcd)
-  if S.Rampage:IsReady() and (S.RecklessAbandon:IsAvailable() and (Player:Rage() >= 90 or S.Recklessness:CooldownRemains() <= Player:GCD())) then
-    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_mt 20"; end
-  end
-  -- rampage,if=!talent.reckless_abandon&!talent.anger_management&rage>=85
-  if S.Rampage:IsReady() and (not S.RecklessAbandon:IsAvailable() and not S.AngerManagement:IsAvailable() and Player:Rage() >= 85) then
-    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_mt 22"; end
-  end
   -- bladestorm,if=buff.enrage.up&cooldown.avatar.remains>=9
   if CDsON() and S.Bladestorm:IsCastable() and (EnrageUp and S.Avatar:CooldownRemains() >= 9) then
-    if Cast(S.Bladestorm, Settings.CommonsOGCD.GCDasOffGCD.Bladestorm, nil, not TargetInMeleeRange) then return "bladestorm slayer_mt 24"; end
+    if Cast(S.Bladestorm, Settings.CommonsOGCD.GCDasOffGCD.Bladestorm, nil, not TargetInMeleeRange) then return "bladestorm slayer_mt 18"; end
   end
   -- onslaught,if=talent.tenderize&buff.brutal_finish.up
   if S.Onslaught:IsReady() and (S.Tenderize:IsAvailable() or Player:BuffUp(S.BrutalFinishBuff)) then
-    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_mt 26"; end
+    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_mt 20"; end
+  end
+  -- rampage,if=talent.anger_management
+  if S.Rampage:IsReady() and (S.AngerManagement:IsAvailable()) then
+    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_mt 22"; end
   end
   -- crushing_blow
   if S.CrushingBlow:IsCastable() then
-    if Cast(S.CrushingBlow, nil, nil, not TargetInMeleeRange) then return "crushing_blow slayer_mt 28"; end
+    if Cast(S.CrushingBlow, nil, nil, not TargetInMeleeRange) then return "crushing_blow slayer_mt 24"; end
   end
   -- onslaught,if=talent.tenderize
   if S.Onslaught:IsReady() and (S.Tenderize:IsAvailable()) then
-    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_mt 30"; end
+    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_mt 26"; end
   end
   -- bloodbath,if=buff.enrage.up
   if S.Bloodbath:IsCastable() and (EnrageUp) then
-    if Cast(S.Bloodbath, nil, nil, not TargetInMeleeRange) then return "bloodbath slayer_mt 32"; end
+    if Cast(S.Bloodbath, nil, nil, not TargetInMeleeRange) then return "bloodbath slayer_mt 28"; end
+  end
+  -- rampage,if=talent.reckless_abandon
+  if S.Rampage:IsReady() and (S.RecklessAbandon:IsAvailable()) then
+    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_mt 30"; end
   end
   -- execute,if=buff.enrage.up&debuff.marked_for_execution.up
   if S.Execute:IsReady() and (EnrageUp and Target:DebuffUp(S.MarkedforExecutionDebuff)) then
-    if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute slayer_mt 34"; end
+    if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute slayer_mt 32"; end
   end
   -- bloodbath
   if S.Bloodbath:IsCastable() then
-    if Cast(S.Bloodbath, nil, nil, not TargetInMeleeRange) then return "bloodbath slayer_mt 36"; end
+    if Cast(S.Bloodbath, nil, nil, not TargetInMeleeRange) then return "bloodbath slayer_mt 34"; end
   end
   -- raging_blow,if=talent.slaughtering_strikes
   if S.RagingBlow:IsCastable() and (S.SlaughteringStrikes:IsAvailable()) then
-    if Cast(S.RagingBlow, nil, nil, not TargetInMeleeRange) then return "raging_blow slayer_mt 38"; end
+    if Cast(S.RagingBlow, nil, nil, not TargetInMeleeRange) then return "raging_blow slayer_mt 36"; end
   end
   -- onslaught
   if S.Onslaught:IsReady() then
-    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_mt 40"; end
+    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_mt 38"; end
   end
   -- execute
   if S.Execute:IsReady() then
-    if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute slayer_mt 42"; end
+    if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute slayer_mt 40"; end
   end
   -- bloodthirst
   if S.Bloodthirst:IsCastable() then
-    if Cast(S.Bloodthirst, nil, nil, not TargetInMeleeRange) then return "bloodthirst slayer_mt 44"; end
+    if Cast(S.Bloodthirst, nil, nil, not TargetInMeleeRange) then return "bloodthirst slayer_mt 42"; end
   end
   -- raging_blow
   if S.RagingBlow:IsCastable() then
-    if Cast(S.RagingBlow, nil, nil, not TargetInMeleeRange) then return "raging_blow slayer_mt 46"; end
+    if Cast(S.RagingBlow, nil, nil, not TargetInMeleeRange) then return "raging_blow slayer_mt 44"; end
   end
   -- whirlwind
   if S.Whirlwind:IsCastable() then
-    if Cast(S.Whirlwind, nil, nil, not Target:IsInMeleeRange(8)) then return "whirlwind slayer_mt 48"; end
+    if Cast(S.Whirlwind, nil, nil, not Target:IsInMeleeRange(8)) then return "whirlwind slayer_mt 46"; end
   end
   -- storm_bolt,if=buff.bladestorm.up
   if S.StormBolt:IsCastable() and (Player:BuffUp(S.Bladestorm)) then
-    if Cast(S.StormBolt, nil, nil, not Target:IsInRange(20)) then return "storm_bolt slayer_mt 50"; end
+    if Cast(S.StormBolt, nil, nil, not Target:IsInRange(20)) then return "storm_bolt slayer_mt 48"; end
   end
 end
 
@@ -451,16 +443,16 @@ local function ThaneST()
   if S.Execute:IsReady() and (S.AshenJuggernaut:IsAvailable() and Player:BuffRemains(S.AshenJuggernautBuff) <= Player:GCD() and EnrageUp) then
     if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute thane_st 16"; end
   end
-  -- rampage,if=talent.anger_management&(rage>=80|cooldown.recklessness.remains<=gcd)
-  if S.Rampage:IsReady() and (S.AngerManagement:IsAvailable() and (Player:Rage() >= 80 or S.Recklessness:CooldownRemains() <= Player:GCD())) then
+  -- rampage,if=talent.bladestorm&cooldown.bladestorm.remains<=gcd&!debuff.champions_might.up
+  if S.Rampage:IsReady() and (S.Bladestorm:IsLearned() and S.Bladestorm:CooldownRemains() <= Player:GCD() and Target:DebuffDown(S.ChampionsMightDebuff)) then
     if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage thane_st 18"; end
   end
-  -- rampage,if=talent.reckless_abandon&(rage>=90|cooldown.recklessness.remains<=gcd)
-  if S.Rampage:IsReady() and (S.RecklessAbandon:IsAvailable() and (Player:Rage() >= 90 or S.Recklessness:CooldownRemains() <= Player:GCD())) then
-    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage thane_st 20"; end
+  -- bladestorm,if=buff.enrage.up&talent.unhinged
+  if CDsON() and S.Bladestorm:IsCastable() and (EnrageUp and S.Unhinged:IsAvailable()) then
+    if Cast(S.Bladestorm, Settings.CommonsOGCD.GCDasOffGCD.Bladestorm, nil, not TargetInMeleeRange) then return "bladestorm thane_st 20"; end
   end
-  -- rampage,if=!talent.reckless_abandon&!talent.anger_management&rage>=85
-  if S.Rampage:IsReady() and (not S.RecklessAbandon:IsAvailable() and not S.AngerManagement:IsAvailable() and Player:Rage() >= 85) then
+  -- rampage,if=talent.anger_management
+  if S.Rampage:IsReady() and (S.AngerManagement:IsAvailable()) then
     if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage thane_st 22"; end
   end
   -- crushing_blow
@@ -474,6 +466,10 @@ local function ThaneST()
   -- bloodbath
   if S.Bloodbath:IsCastable() then
     if Cast(S.Bloodbath, nil, nil, not TargetInMeleeRange) then return "bloodbath thane_st 28"; end
+  end
+  -- rampage,if=talent.reckless_abandon
+  if S.Rampage:IsReady() and (S.RecklessAbandon:IsAvailable()) then
+    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage thane_st 30"; end
   end
   -- raging_blow
   if S.RagingBlow:IsCastable() then
@@ -546,16 +542,16 @@ local function ThaneMT()
   if S.Execute:IsReady() and (S.AshenJuggernaut:IsAvailable() and Player:BuffRemains(S.AshenJuggernautBuff) <= Player:GCD() and EnrageUp) then
     if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute thane_mt 18"; end
   end
-  -- rampage,if=talent.anger_management&(rage>=80|cooldown.recklessness.remains<=gcd)
-  if S.Rampage:IsReady() and (S.AngerManagement:IsAvailable() and (Player:Rage() >= 80 or S.Recklessness:CooldownRemains() <= Player:GCD())) then
+  -- rampage,if=talent.bladestorm&cooldown.bladestorm.remains<=gcd&!debuff.champions_might.up
+  if S.Rampage:IsReady() and (S.Bladestorm:IsLearned() and S.Bladestorm:CooldownRemains() <= Player:GCD() and Target:DebuffDown(S.ChampionsMightDebuff)) then
     if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage thane_mt 20"; end
   end
-  -- rampage,if=talent.reckless_abandon&(rage>=90|cooldown.recklessness.remains<=gcd)
-  if S.Rampage:IsReady() and (S.RecklessAbandon:IsAvailable() and (Player:Rage() >= 90 or S.Recklessness:CooldownRemains() <= Player:GCD())) then
-    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage thane_mt 22"; end
+  -- bladestorm,if=buff.enrage.up
+  if CDsON() and S.Bladestorm:IsCastable() and (EnrageUp) then
+    if Cast(S.Bladestorm, Settings.CommonsOGCD.GCDasOffGCD.Bladestorm, nil, not TargetInMeleeRange) then return "bladestorm thane_mt 22"; end
   end
-  -- rampage,if=!talent.reckless_abandon&!talent.anger_management&rage>=85
-  if S.Rampage:IsReady() and (not S.RecklessAbandon:IsAvailable() and not S.AngerManagement:IsAvailable() and Player:Rage() >= 85) then
+  -- rampage,if=talent.anger_management
+  if S.Rampage:IsReady() and (S.AngerManagement:IsAvailable()) then
     if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage thane_mt 24"; end
   end
   -- crushing_blow,if=buff.enrage.up
@@ -569,6 +565,10 @@ local function ThaneMT()
   -- bloodbath
   if S.Bloodbath:IsCastable() then
     if Cast(S.Bloodbath, nil, nil, not TargetInMeleeRange) then return "bloodbath thane_mt 30"; end
+  end
+  -- rampage,if=talent.reckless_abandon
+  if S.Rampage:IsReady() and (S.RecklessAbandon:IsAvailable()) then
+    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage thane_mt 32"; end
   end
   -- bloodthirst
   if S.Bloodthirst:IsCastable() then

--- a/HeroRotation_Warrior/Fury.lua
+++ b/HeroRotation_Warrior/Fury.lua
@@ -15,7 +15,7 @@ local Item       = HL.Item
 -- HeroRotation
 local HR         = HeroRotation
 local Cast       = HR.Cast
-local AoEON      = HR.AoEON
+local AoEON      = HR.AOEON
 local CDsON      = HR.CDsON
 -- Num/Bool Helper Functions
 local num        = HR.Commons.Everyone.num
@@ -241,73 +241,77 @@ local function SlayerST()
   if S.Rampage:IsReady() and (S.Bladestorm:IsLearned() and S.Bladestorm:CooldownRemains() <= Player:GCD() and Target:DebuffDown(S.ChampionsMightDebuff)) then
     if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_st 14"; end
   end
+  -- rampage,if=talent.anger_management&(rage>=80|cooldown.recklessness.remains<=gcd)
+  if S.Rampage:IsReady() and (S.AngerManagement:IsAvailable() and (Player:Rage() >= 80 or S.Recklessness:CooldownRemains() <= Player:GCD())) then
+    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_st 16"; end 
+  end
+  -- rampage,if=talent.reckless_abandon&(rage>=90|cooldown.recklessness.remains<=gcd)
+  if S.Rampage:IsReady() and (S.RecklessAbandon:IsAvailable() and (Player:Rage() >= 90 or S.Recklessness:CooldownRemains() <= Player:GCD())) then
+    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_st 18"; end
+  end
+  -- rampage,if=!talent.reckless_abandon&!talent.anger_management&rage>=85
+  if S.Rampage:IsReady() and (not S.RecklessAbandon:IsAvailable() and not S.AngerManagement:IsAvailable() and Player:Rage() >= 85) then
+    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_st 20"; end
+  end
   -- bladestorm,if=buff.enrage.up&cooldown.avatar.remains>=9
   if CDsON() and S.Bladestorm:IsCastable() and (EnrageUp and S.Avatar:CooldownRemains() >= 9) then
-    if Cast(S.Bladestorm, Settings.CommonsOGCD.GCDasOffGCD.Bladestorm, nil, not TargetInMeleeRange) then return "bladestorm slayer_st 16"; end
+    if Cast(S.Bladestorm, Settings.CommonsOGCD.GCDasOffGCD.Bladestorm, nil, not TargetInMeleeRange) then return "bladestorm slayer_st 22"; end
   end
   -- onslaught,if=talent.tenderize&buff.brutal_finish.up
   if S.Onslaught:IsReady() and (S.Tenderize:IsAvailable() or Player:BuffUp(S.BrutalFinishBuff)) then
-    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_st 18"; end
-  end
-  -- rampage,if=talent.anger_management
-  if S.Rampage:IsReady() and (S.AngerManagement:IsAvailable()) then
-    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_st 20"; end
+    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_st 24"; end
   end
   -- crushing_blow
   if S.CrushingBlow:IsCastable() then
-    if Cast(S.CrushingBlow, nil, nil, not TargetInMeleeRange) then return "crushing_blow slayer_st 22"; end
+    if Cast(S.CrushingBlow, nil, nil, not TargetInMeleeRange) then return "crushing_blow slayer_st 26"; end
   end
   -- onslaught,if=talent.tenderize
   if S.Onslaught:IsReady() and (S.Tenderize:IsAvailable()) then
-    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_st 24"; end
+    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_st 28"; end
   end
   -- bloodbath,if=rage<100|target.health.pct<35&talent.vicious_contempt
   if S.Bloodbath:IsCastable() and (Player:Rage() < 100 or Target:HealthPercentage() < 35 and S.ViciousContempt:IsAvailable()) then
-    if Cast(S.Bloodbath, nil, nil, not TargetInMeleeRange) then return "bloodbath slayer_st 26"; end
+    if Cast(S.Bloodbath, nil, nil, not TargetInMeleeRange) then return "bloodbath slayer_st 30"; end
   end
   -- raging_blow,if=rage<100&!buff.opportunist.up
   if S.RagingBlow:IsCastable() and (Player:Rage() < 100 and Player:BuffDown(S.OpportunistBuff)) then
-    if Cast(S.RagingBlow, nil, nil, not TargetInMeleeRange) then return "raging_blow slayer_st 28"; end
-  end
-  -- rampage,if=talent.reckless_abandon
-  if S.Rampage:IsReady() and (S.RecklessAbandon:IsAvailable()) then
-    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_st 30"; end
+    if Cast(S.RagingBlow, nil, nil, not TargetInMeleeRange) then return "raging_blow slayer_st 32"; end
   end
   -- execute,if=buff.enrage.up&debuff.marked_for_execution.up
   if S.Execute:IsReady() and (EnrageUp and Target:DebuffUp(S.MarkedforExecutionDebuff)) then
-    if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute slayer_st 32"; end
+    if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute slayer_st 34"; end
   end
   -- bloodthirst,if=!talent.reckless_abandon&buff.enrage.up
   if S.Bloodthirst:IsCastable() and (not S.RecklessAbandon:IsAvailable() and EnrageUp) then
-    if Cast(S.Bloodthirst, nil, nil, not TargetInMeleeRange) then return "bloodthirst slayer_st 34"; end
+    if Cast(S.Bloodthirst, nil, nil, not TargetInMeleeRange) then return "bloodthirst slayer_st 36"; end
   end
   -- raging_blow
   if S.RagingBlow:IsCastable() then
-    if Cast(S.RagingBlow, nil, nil, not TargetInMeleeRange) then return "raging_blow slayer_st 36"; end
+    if Cast(S.RagingBlow, nil, nil, not TargetInMeleeRange) then return "raging_blow slayer_st 38"; end
   end
   -- onslaught
   if S.Onslaught:IsReady() then
-    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_st 38"; end
+    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_st 40"; end
   end
   -- execute
   if S.Execute:IsReady() then
-    if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute slayer_st 40"; end
+    if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute slayer_st 42"; end
   end
   -- bloodthirst
   if S.Bloodthirst:IsCastable() then
-    if Cast(S.Bloodthirst, nil, nil, not TargetInMeleeRange) then return "bloodthirst slayer_st 42"; end
+    if Cast(S.Bloodthirst, nil, nil, not TargetInMeleeRange) then return "bloodthirst slayer_st 44"; end
   end
   -- whirlwind,if=talent.meat_cleaver
   if S.Whirlwind:IsCastable() and (S.MeatCleaver:IsAvailable()) then
-    if Cast(S.Whirlwind, nil, nil, not Target:IsInMeleeRange(8)) then return "whirlwind slayer_st 44"; end
+    if Cast(S.Whirlwind, nil, nil, not Target:IsInMeleeRange(8)) then return "whirlwind slayer_st 46"; end
   end
   -- slam
   if S.Slam:IsCastable() then
-    if Cast(S.Slam, nil, nil, not TargetInMeleeRange) then return "slam slayer_st 46"; end
+    if Cast(S.Slam, nil, nil, not TargetInMeleeRange) then return "slam slayer_st 48"; end
   end
   -- storm_bolt,if=buff.bladestorm.up
   if S.StormBolt:IsCastable() and (Player:BuffUp(S.Bladestorm)) then
-    if Cast(S.StormBolt, nil, nil, not Target:IsInRange(20)) then return "storm_bolt slayer_st 48"; end
+    if Cast(S.StormBolt, nil, nil, not Target:IsInRange(20)) then return "storm_bolt slayer_st 50"; end
   end
 end
 
@@ -344,69 +348,73 @@ local function SlayerMT()
   if S.Rampage:IsReady() and (S.Bladestorm:IsLearned() and S.Bladestorm:CooldownRemains() <= Player:GCD() and Target:DebuffDown(S.ChampionsMightDebuff)) then
     if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_mt 16"; end
   end
+  -- rampage,if=talent.anger_management&(rage>=80|cooldown.recklessness.remains<=gcd)
+  if S.Rampage:IsReady() and (S.AngerManagement:IsAvailable() and (Player:Rage() >= 80 or S.Recklessness:CooldownRemains() <= Player:GCD())) then
+    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_mt 18"; end 
+  end
+  -- rampage,if=talent.reckless_abandon&(rage>=90|cooldown.recklessness.remains<=gcd)
+  if S.Rampage:IsReady() and (S.RecklessAbandon:IsAvailable() and (Player:Rage() >= 90 or S.Recklessness:CooldownRemains() <= Player:GCD())) then
+    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_mt 20"; end
+  end
+  -- rampage,if=!talent.reckless_abandon&!talent.anger_management&rage>=85
+  if S.Rampage:IsReady() and (not S.RecklessAbandon:IsAvailable() and not S.AngerManagement:IsAvailable() and Player:Rage() >= 85) then
+    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_mt 22"; end
+  end
   -- bladestorm,if=buff.enrage.up&cooldown.avatar.remains>=9
   if CDsON() and S.Bladestorm:IsCastable() and (EnrageUp and S.Avatar:CooldownRemains() >= 9) then
-    if Cast(S.Bladestorm, Settings.CommonsOGCD.GCDasOffGCD.Bladestorm, nil, not TargetInMeleeRange) then return "bladestorm slayer_mt 18"; end
+    if Cast(S.Bladestorm, Settings.CommonsOGCD.GCDasOffGCD.Bladestorm, nil, not TargetInMeleeRange) then return "bladestorm slayer_mt 24"; end
   end
   -- onslaught,if=talent.tenderize&buff.brutal_finish.up
   if S.Onslaught:IsReady() and (S.Tenderize:IsAvailable() or Player:BuffUp(S.BrutalFinishBuff)) then
-    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_mt 20"; end
-  end
-  -- rampage,if=talent.anger_management
-  if S.Rampage:IsReady() and (S.AngerManagement:IsAvailable()) then
-    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_mt 22"; end
+    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_mt 26"; end
   end
   -- crushing_blow
   if S.CrushingBlow:IsCastable() then
-    if Cast(S.CrushingBlow, nil, nil, not TargetInMeleeRange) then return "crushing_blow slayer_mt 24"; end
+    if Cast(S.CrushingBlow, nil, nil, not TargetInMeleeRange) then return "crushing_blow slayer_mt 28"; end
   end
   -- onslaught,if=talent.tenderize
   if S.Onslaught:IsReady() and (S.Tenderize:IsAvailable()) then
-    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_mt 26"; end
+    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_mt 30"; end
   end
   -- bloodbath,if=buff.enrage.up
   if S.Bloodbath:IsCastable() and (EnrageUp) then
-    if Cast(S.Bloodbath, nil, nil, not TargetInMeleeRange) then return "bloodbath slayer_mt 28"; end
-  end
-  -- rampage,if=talent.reckless_abandon
-  if S.Rampage:IsReady() and (S.RecklessAbandon:IsAvailable()) then
-    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage slayer_mt 30"; end
+    if Cast(S.Bloodbath, nil, nil, not TargetInMeleeRange) then return "bloodbath slayer_mt 32"; end
   end
   -- execute,if=buff.enrage.up&debuff.marked_for_execution.up
   if S.Execute:IsReady() and (EnrageUp and Target:DebuffUp(S.MarkedforExecutionDebuff)) then
-    if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute slayer_mt 32"; end
+    if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute slayer_mt 34"; end
   end
   -- bloodbath
   if S.Bloodbath:IsCastable() then
-    if Cast(S.Bloodbath, nil, nil, not TargetInMeleeRange) then return "bloodbath slayer_mt 34"; end
+    if Cast(S.Bloodbath, nil, nil, not TargetInMeleeRange) then return "bloodbath slayer_mt 36"; end
   end
   -- raging_blow,if=talent.slaughtering_strikes
   if S.RagingBlow:IsCastable() and (S.SlaughteringStrikes:IsAvailable()) then
-    if Cast(S.RagingBlow, nil, nil, not TargetInMeleeRange) then return "raging_blow slayer_mt 36"; end
+    if Cast(S.RagingBlow, nil, nil, not TargetInMeleeRange) then return "raging_blow slayer_mt 38"; end
   end
   -- onslaught
   if S.Onslaught:IsReady() then
-    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_mt 38"; end
+    if Cast(S.Onslaught, nil, nil, not TargetInMeleeRange) then return "onslaught slayer_mt 40"; end
   end
   -- execute
   if S.Execute:IsReady() then
-    if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute slayer_mt 40"; end
+    if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute slayer_mt 42"; end
   end
   -- bloodthirst
   if S.Bloodthirst:IsCastable() then
-    if Cast(S.Bloodthirst, nil, nil, not TargetInMeleeRange) then return "bloodthirst slayer_mt 42"; end
+    if Cast(S.Bloodthirst, nil, nil, not TargetInMeleeRange) then return "bloodthirst slayer_mt 44"; end
   end
   -- raging_blow
   if S.RagingBlow:IsCastable() then
-    if Cast(S.RagingBlow, nil, nil, not TargetInMeleeRange) then return "raging_blow slayer_mt 44"; end
+    if Cast(S.RagingBlow, nil, nil, not TargetInMeleeRange) then return "raging_blow slayer_mt 46"; end
   end
   -- whirlwind
   if S.Whirlwind:IsCastable() then
-    if Cast(S.Whirlwind, nil, nil, not Target:IsInMeleeRange(8)) then return "whirlwind slayer_mt 46"; end
+    if Cast(S.Whirlwind, nil, nil, not Target:IsInMeleeRange(8)) then return "whirlwind slayer_mt 48"; end
   end
   -- storm_bolt,if=buff.bladestorm.up
   if S.StormBolt:IsCastable() and (Player:BuffUp(S.Bladestorm)) then
-    if Cast(S.StormBolt, nil, nil, not Target:IsInRange(20)) then return "storm_bolt slayer_mt 48"; end
+    if Cast(S.StormBolt, nil, nil, not Target:IsInRange(20)) then return "storm_bolt slayer_mt 50"; end
   end
 end
 
@@ -443,16 +451,16 @@ local function ThaneST()
   if S.Execute:IsReady() and (S.AshenJuggernaut:IsAvailable() and Player:BuffRemains(S.AshenJuggernautBuff) <= Player:GCD() and EnrageUp) then
     if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute thane_st 16"; end
   end
-  -- rampage,if=talent.bladestorm&cooldown.bladestorm.remains<=gcd&!debuff.champions_might.up
-  if S.Rampage:IsReady() and (S.Bladestorm:IsLearned() and S.Bladestorm:CooldownRemains() <= Player:GCD() and Target:DebuffDown(S.ChampionsMightDebuff)) then
+  -- rampage,if=talent.anger_management&(rage>=80|cooldown.recklessness.remains<=gcd)
+  if S.Rampage:IsReady() and (S.AngerManagement:IsAvailable() and (Player:Rage() >= 80 or S.Recklessness:CooldownRemains() <= Player:GCD())) then
     if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage thane_st 18"; end
   end
-  -- bladestorm,if=buff.enrage.up&talent.unhinged
-  if CDsON() and S.Bladestorm:IsCastable() and (EnrageUp and S.Unhinged:IsAvailable()) then
-    if Cast(S.Bladestorm, Settings.CommonsOGCD.GCDasOffGCD.Bladestorm, nil, not TargetInMeleeRange) then return "bladestorm thane_st 20"; end
+  -- rampage,if=talent.reckless_abandon&(rage>=90|cooldown.recklessness.remains<=gcd)
+  if S.Rampage:IsReady() and (S.RecklessAbandon:IsAvailable() and (Player:Rage() >= 90 or S.Recklessness:CooldownRemains() <= Player:GCD())) then
+    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage thane_st 20"; end
   end
-  -- rampage,if=talent.anger_management
-  if S.Rampage:IsReady() and (S.AngerManagement:IsAvailable()) then
+  -- rampage,if=!talent.reckless_abandon&!talent.anger_management&rage>=85
+  if S.Rampage:IsReady() and (not S.RecklessAbandon:IsAvailable() and not S.AngerManagement:IsAvailable() and Player:Rage() >= 85) then
     if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage thane_st 22"; end
   end
   -- crushing_blow
@@ -466,10 +474,6 @@ local function ThaneST()
   -- bloodbath
   if S.Bloodbath:IsCastable() then
     if Cast(S.Bloodbath, nil, nil, not TargetInMeleeRange) then return "bloodbath thane_st 28"; end
-  end
-  -- rampage,if=talent.reckless_abandon
-  if S.Rampage:IsReady() and (S.RecklessAbandon:IsAvailable()) then
-    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage thane_st 30"; end
   end
   -- raging_blow
   if S.RagingBlow:IsCastable() then
@@ -542,16 +546,16 @@ local function ThaneMT()
   if S.Execute:IsReady() and (S.AshenJuggernaut:IsAvailable() and Player:BuffRemains(S.AshenJuggernautBuff) <= Player:GCD() and EnrageUp) then
     if Cast(S.Execute, nil, nil, not TargetInMeleeRange) then return "execute thane_mt 18"; end
   end
-  -- rampage,if=talent.bladestorm&cooldown.bladestorm.remains<=gcd&!debuff.champions_might.up
-  if S.Rampage:IsReady() and (S.Bladestorm:IsLearned() and S.Bladestorm:CooldownRemains() <= Player:GCD() and Target:DebuffDown(S.ChampionsMightDebuff)) then
+  -- rampage,if=talent.anger_management&(rage>=80|cooldown.recklessness.remains<=gcd)
+  if S.Rampage:IsReady() and (S.AngerManagement:IsAvailable() and (Player:Rage() >= 80 or S.Recklessness:CooldownRemains() <= Player:GCD())) then
     if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage thane_mt 20"; end
   end
-  -- bladestorm,if=buff.enrage.up
-  if CDsON() and S.Bladestorm:IsCastable() and (EnrageUp) then
-    if Cast(S.Bladestorm, Settings.CommonsOGCD.GCDasOffGCD.Bladestorm, nil, not TargetInMeleeRange) then return "bladestorm thane_mt 22"; end
+  -- rampage,if=talent.reckless_abandon&(rage>=90|cooldown.recklessness.remains<=gcd)
+  if S.Rampage:IsReady() and (S.RecklessAbandon:IsAvailable() and (Player:Rage() >= 90 or S.Recklessness:CooldownRemains() <= Player:GCD())) then
+    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage thane_mt 22"; end
   end
-  -- rampage,if=talent.anger_management
-  if S.Rampage:IsReady() and (S.AngerManagement:IsAvailable()) then
+  -- rampage,if=!talent.reckless_abandon&!talent.anger_management&rage>=85
+  if S.Rampage:IsReady() and (not S.RecklessAbandon:IsAvailable() and not S.AngerManagement:IsAvailable() and Player:Rage() >= 85) then
     if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage thane_mt 24"; end
   end
   -- crushing_blow,if=buff.enrage.up
@@ -565,10 +569,6 @@ local function ThaneMT()
   -- bloodbath
   if S.Bloodbath:IsCastable() then
     if Cast(S.Bloodbath, nil, nil, not TargetInMeleeRange) then return "bloodbath thane_mt 30"; end
-  end
-  -- rampage,if=talent.reckless_abandon
-  if S.Rampage:IsReady() and (S.RecklessAbandon:IsAvailable()) then
-    if Cast(S.Rampage, nil, nil, not TargetInMeleeRange) then return "rampage thane_mt 32"; end
   end
   -- bloodthirst
   if S.Bloodthirst:IsCastable() then

--- a/HeroRotation_Warrior/Fury.lua
+++ b/HeroRotation_Warrior/Fury.lua
@@ -38,7 +38,13 @@ local OnUseExcludes = {
 
 --- ===== GUI Settings =====
 local Everyone = HR.Commons.Everyone
-local Settings = HR.GUISettings.APL.Warrior
+local Settings = {
+  General = HR.GUISettings.General,
+  Commons = HR.GUISettings.APL.Warrior.Commons,
+  CommonsDS = HR.GUISettings.APL.Warrior.CommonsDS,
+  CommonsOGCD = HR.GUISettings.APL.Warrior.CommonsOGCD,
+  Fury = HR.GUISettings.APL.Warrior.Fury
+}
 
 --- ===== Rotation Variables =====
 local VarSTPlanning, VarAddsRemain
@@ -137,30 +143,21 @@ end, "PLAYER_EQUIPMENT_CHANGED", "SPELLS_CHANGED", "LEARNED_SPELL_IN_TAB")
 
 --- ===== Rotation Functions =====
 local function Precombat()
-  -- Use Treacherous Transmitter at the start of precombat if enabled
-  if Settings.Commons["Sync Trinkets with CD Toggle for PreCombat"].UseTreacherousTransmitter then
-    if I.TreacherousTransmitter:IsEquippedAndReady() then
-      if Cast(I.TreacherousTransmitter) then return "use_treacherous_transmitter precombat"; end
-    end
-  end
-
-  -- Use other trinkets before combat if enabled
-  if Settings.Commons["Sync Trinkets with CD Toggle for PreCombat"].UseTrinkets then
-    if I.ImperfectAscendancySerum:IsEquippedAndReady() then
-      if Cast(I.ImperfectAscendancySerum) then return "use_imperfect_ascendancy_serum precombat"; end
-    end
-    -- Add logic for other trinkets here
-  end
-
-  -- Sync cooldowns before combat if enabled
-  if Settings.Commons["Sync Trinkets with CD Toggle for PreCombat"].SyncCooldowns then
-    -- Add logic for syncing cooldowns precombat
-    -- For example:
-    if S.Recklessness:IsCastable() and S.Avatar:IsCastable() then
-      if Cast(S.Recklessness) then return "recklessness precombat sync"; end
-      if Cast(S.Avatar) then return "avatar precombat sync"; end
-    end
-  end
+  -- flask
+  -- food
+  -- augmentation
+  -- snapshot_stats
+  -- variable,name=trinket_1_exclude,value=trinket.1.is.treacherous_transmitter
+  -- variable,name=trinket_2_exclude,value=trinket.2.is.treacherous_transmitter
+  -- variable,name=trinket_1_sync,op=setif,value=1,value_else=0.5,condition=trinket.1.has_use_buff&(trinket.1.cooldown.duration%%cooldown.avatar.duration=0|trinket.1.cooldown.duration%%cooldown.odyns_fury.duration=0)
+  -- variable,name=trinket_2_sync,op=setif,value=1,value_else=0.5,condition=trinket.2.has_use_buff&(trinket.2.cooldown.duration%%cooldown.avatar.duration=0|trinket.2.cooldown.duration%%cooldown.odyns_fury.duration=0)
+  -- variable,name=trinket_1_buffs,value=trinket.1.has_use_buff|(trinket.1.has_stat.any_dps&!variable.trinket_1_exclude)
+  -- variable,name=trinket_2_buffs,value=trinket.2.has_use_buff|(trinket.2.has_stat.any_dps&!variable.trinket_2_exclude)
+  -- variable,name=trinket_priority,op=setif,value=2,value_else=1,condition=!variable.trinket_1_buffs&variable.trinket_2_buffs|variable.trinket_2_buffs&((trinket.2.cooldown.duration%trinket.2.proc.any_dps.duration)*(1.5+trinket.2.has_buff.strength)*(variable.trinket_2_sync))>((trinket.1.cooldown.duration%trinket.1.proc.any_dps.duration)*(1.5+trinket.1.has_buff.strength)*(variable.trinket_1_sync))
+  -- variable,name=trinket_1_manual,value=trinket.1.is.algethar_puzzle_box
+  -- variable,name=trinket_2_manual,value=trinket.2.is.algethar_puzzle_box
+  -- Note: Moved the above variables to declarations and PLAYER_EQUIPMENT_CHANGED.
+  -- Manually added: Group Battle Shout check
 
   -- Check if cooldowns are enabled
   if CDsON() then

--- a/HeroRotation_Warrior/Fury.lua
+++ b/HeroRotation_Warrior/Fury.lua
@@ -15,7 +15,7 @@ local Item       = HL.Item
 -- HeroRotation
 local HR         = HeroRotation
 local Cast       = HR.Cast
-local AoEON      = HR.AoEON
+local AoEON      = HR.AOEON
 local CDsON      = HR.CDsON
 -- Num/Bool Helper Functions
 local num        = HR.Commons.Everyone.num

--- a/HeroRotation_Warrior/Settings.lua
+++ b/HeroRotation_Warrior/Settings.lua
@@ -24,6 +24,16 @@ HR.GUISettings.APL.Warrior = {
       Trinkets = true,
       Items = true,
     },
+    -- Trinket and PreCombat Sync Settings
+    ["Sync Trinkets with CD Toggle"] = {
+      Enabled = false,
+      IncludeTrinkets = false,
+    },
+    ["Sync Trinkets with CD Toggle for PreCombat"] = {
+      UseTrinkets = false,
+      SyncCooldowns = false,
+      UseTreacherousTransmitter = false,
+    },
   },
   CommonsDS = {
     DisplayStyle = {
@@ -117,6 +127,14 @@ local CP_Protection = CreateChildPanel(CP_Warrior, "Protection")
 CreateARPanelOptions(CP_Warrior, "APL.Warrior.Commons")
 CreatePanelOption("CheckButton", CP_Warrior, "APL.Warrior.Commons.ShoutDuringCombat", "Battle Shout during combat", "Enable this option to allow Battle Shout to be suggested during combat (for re-buffing fallen allies or when the buff expires during combat).")
 CreatePanelOption("Slider", CP_Warrior, "APL.Warrior.Commons.VictoryRushHP", {0, 100, 1}, "Victory Rush HP", "Set the Victory Rush/Impending Victory HP threshold. Set to 0 to disable.")
+
+-- New options for Commons
+CreatePanelOption("CheckButton", CP_Warrior, "APL.Warrior.Commons.Sync Trinkets with CD Toggle.Enabled", "Enable CD Toggle", "Enable this option to use the cooldown toggle for major abilities during combat.")
+CreatePanelOption("CheckButton", CP_Warrior, "APL.Warrior.Commons.Sync Trinkets with CD Toggle.IncludeTrinkets", "Include Trinkets in CD Toggle", "Enable this option to include trinkets in the cooldown toggle system.")
+CreatePanelOption("CheckButton", CP_Warrior, "APL.Warrior.Commons.Sync Trinkets with CD Toggle for PreCombat.UseTrinkets", "Use Trinkets Precombat", "Enable this option to use trinkets before combat starts, if beneficial.")
+CreatePanelOption("CheckButton", CP_Warrior, "APL.Warrior.Commons.Sync Trinkets with CD Toggle for PreCombat.SyncCooldowns", "Sync Cooldowns Precombat", "Enable this option to synchronize cooldowns before entering combat for optimal opener.")
+CreatePanelOption("CheckButton", CP_Warrior, "APL.Warrior.Commons.Sync Trinkets with CD Toggle for PreCombat.UseTreacherousTransmitter", "Use Treacherous Transmitter Precombat", "Enable this option to use Treacherous Transmitter trinket at the start of precombat phase.")
+
 CreateARPanelOptions(CP_WarriorDS, "APL.Warrior.CommonsDS")
 CreateARPanelOptions(CP_WarriorOGCD, "APL.Warrior.CommonsOGCD")
 

--- a/HeroRotation_Warrior/Settings.lua
+++ b/HeroRotation_Warrior/Settings.lua
@@ -24,6 +24,8 @@ HR.GUISettings.APL.Warrior = {
       Trinkets = true,
       Items = true,
     },
+    SyncTrinketsToCDs = false,
+    UseCDsInPrecombat = false,
   },
   CommonsDS = {
     DisplayStyle = {
@@ -117,6 +119,8 @@ local CP_Protection = CreateChildPanel(CP_Warrior, "Protection")
 CreateARPanelOptions(CP_Warrior, "APL.Warrior.Commons")
 CreatePanelOption("CheckButton", CP_Warrior, "APL.Warrior.Commons.ShoutDuringCombat", "Battle Shout during combat", "Enable this option to allow Battle Shout to be suggested during combat (for re-buffing fallen allies or when the buff expires during combat).")
 CreatePanelOption("Slider", CP_Warrior, "APL.Warrior.Commons.VictoryRushHP", {0, 100, 1}, "Victory Rush HP", "Set the Victory Rush/Impending Victory HP threshold. Set to 0 to disable.")
+CreatePanelOption("CheckButton", CP_Warrior, "APL.Warrior.Commons.SyncTrinketsToCDs", "Sync Trinkets to CDs", "Enable this option to sync trinket usage with major cooldowns.")
+CreatePanelOption("CheckButton", CP_Warrior, "APL.Warrior.Commons.UseCDsInPrecombat", "Use CDs in Precombat", "Enable this option to use cooldowns and on-use trinkets in the precombat routine.")
 CreateARPanelOptions(CP_WarriorDS, "APL.Warrior.CommonsDS")
 CreateARPanelOptions(CP_WarriorOGCD, "APL.Warrior.CommonsOGCD")
 

--- a/HeroRotation_Warrior/Settings.lua
+++ b/HeroRotation_Warrior/Settings.lua
@@ -24,16 +24,6 @@ HR.GUISettings.APL.Warrior = {
       Trinkets = true,
       Items = true,
     },
-    -- Trinket and PreCombat Sync Settings
-    ["Sync Trinkets with CD Toggle"] = {
-      Enabled = false,
-      IncludeTrinkets = false,
-    },
-    ["Sync Trinkets with CD Toggle for PreCombat"] = {
-      UseTrinkets = false,
-      SyncCooldowns = false,
-      UseTreacherousTransmitter = false,
-    },
   },
   CommonsDS = {
     DisplayStyle = {
@@ -127,14 +117,6 @@ local CP_Protection = CreateChildPanel(CP_Warrior, "Protection")
 CreateARPanelOptions(CP_Warrior, "APL.Warrior.Commons")
 CreatePanelOption("CheckButton", CP_Warrior, "APL.Warrior.Commons.ShoutDuringCombat", "Battle Shout during combat", "Enable this option to allow Battle Shout to be suggested during combat (for re-buffing fallen allies or when the buff expires during combat).")
 CreatePanelOption("Slider", CP_Warrior, "APL.Warrior.Commons.VictoryRushHP", {0, 100, 1}, "Victory Rush HP", "Set the Victory Rush/Impending Victory HP threshold. Set to 0 to disable.")
-
--- New options for Commons
-CreatePanelOption("CheckButton", CP_Warrior, "APL.Warrior.Commons.Sync Trinkets with CD Toggle.Enabled", "Enable CD Toggle", "Enable this option to use the cooldown toggle for major abilities during combat.")
-CreatePanelOption("CheckButton", CP_Warrior, "APL.Warrior.Commons.Sync Trinkets with CD Toggle.IncludeTrinkets", "Include Trinkets in CD Toggle", "Enable this option to include trinkets in the cooldown toggle system.")
-CreatePanelOption("CheckButton", CP_Warrior, "APL.Warrior.Commons.Sync Trinkets with CD Toggle for PreCombat.UseTrinkets", "Use Trinkets Precombat", "Enable this option to use trinkets before combat starts, if beneficial.")
-CreatePanelOption("CheckButton", CP_Warrior, "APL.Warrior.Commons.Sync Trinkets with CD Toggle for PreCombat.SyncCooldowns", "Sync Cooldowns Precombat", "Enable this option to synchronize cooldowns before entering combat for optimal opener.")
-CreatePanelOption("CheckButton", CP_Warrior, "APL.Warrior.Commons.Sync Trinkets with CD Toggle for PreCombat.UseTreacherousTransmitter", "Use Treacherous Transmitter Precombat", "Enable this option to use Treacherous Transmitter trinket at the start of precombat phase.")
-
 CreateARPanelOptions(CP_WarriorDS, "APL.Warrior.CommonsDS")
 CreateARPanelOptions(CP_WarriorOGCD, "APL.Warrior.CommonsOGCD")
 

--- a/HeroRotation_Warrior/Warrior.lua
+++ b/HeroRotation_Warrior/Warrior.lua
@@ -254,6 +254,8 @@ Item.Warrior.Commons = {
   AlgetharPuzzleBox                     = Item(193701, {13, 14}),
   -- TWW Trinkets
   TreacherousTransmitter                = Item(221023, {13, 14}),
+  ImperfectAscendancySerum              = Item(225654, {13, 14}), -- Imperfect Ascendancy Serum
+  SkarmorakShard                         = Item(219300, {13, 14}), -- Skarmorak Shard
   -- Other Items
   Fyralath                              = Item(206448, {16}),
 }


### PR DESCRIPTION
Hi, based on your last feedback, I’ve added a couple of new settings to give more flexibility in how trinkets and cooldowns are handled in the Fury Warrior rotation:

1. **Sync Trinkets with CDs:** This lets you sync trinkets with major cooldowns for better burst potential. It’s off by default to maintain the current setup, but it’s there for anyone who wants to try it out.
2. **Use CDs Precombat:** This enables cooldowns and specific trinkets in the pre-combat routine for a stronger opener. I’ve adjusted the Treacherous Transmitter logic (and similar trinkets) so they’re cast before any major cooldowns, not after Recklessness, and before Avatar to avoid wasting Recklessness uptime. Note that this only affects trinkets with similar mechanics—standard on-use trinkets shouldn’t be used pre-combat.

These settings keep the default behavior intact while allowing fellow HR users to experiment with these tweaks. If this works for you, I can replicate it in the Arms rotation as well. What do you think, Cil?