### PR TITLE
assassination updates

### DIFF
--- a/HeroRotation_Rogue/Assassination.lua
+++ b/HeroRotation_Rogue/Assassination.lua
@@ -431,7 +431,13 @@ local function Stealthed (ReturnSpellOnly, ForceStealth)
     if HR.AoEON() then
       local TargetIfUnit = CheckTargetIfTarget("min", RuptureTargetIfFunc, RuptureIfFunc)
       if TargetIfUnit and TargetIfUnit:GUID() ~= Target:GUID() then
-        CastLeftNameplate(TargetIfUnit, S.Rupture)
+        if Settings.Assassination.ShowIndiscriminateCarnageOnMainIcon then
+          if Cast(S.Rupture, nil, nil, not TargetInMeleeRange) then
+            return "Cast Rupture (Stealth Indiscriminate Carnage)"
+          end
+        else
+          return CastLeftNameplate(TargetIfUnit, S.Rupture)
+        end
       end
     end
     if RuptureIfFunc(Target) then
@@ -460,7 +466,13 @@ local function Stealthed (ReturnSpellOnly, ForceStealth)
     if HR.AoEON() then
       local TargetIfUnit = CheckTargetIfTarget("min", GarroteTargetIfFunc, GarroteIfFunc)
       if TargetIfUnit and TargetIfUnit:GUID() ~= Target:GUID() then
-        return CastLeftNameplate(TargetIfUnit, S.Garrote)
+        if Settings.Assassination.ShowIndiscriminateCarnageOnMainIcon then
+          if Cast(S.Garrote, nil, nil, not TargetInMeleeRange) then
+            return "Cast Garrote (Improved Garrote Carnage)"
+          end
+        else
+          return CastLeftNameplate(TargetIfUnit, S.Garrote)
+        end
       end
     end
     if GarroteIfFunc(Target) then
@@ -796,7 +808,7 @@ local function CDs ()
   -- actions.cds+=/kingsbane,if=(debuff.shiv.up|cooldown.shiv.remains<6)&buff.envenom.up&(cooldown.deathmark.remains>=50|dot.deathmark.ticking)|fight_remains<=15
   if S.Kingsbane:IsReady() then
     if (Target:DebuffUp(S.ShivDebuff) or S.Shiv:CooldownRemains() < 6) and Player:BuffUp(S.Envenom)
-      and (S.Deathmark:CooldownRemains() >= 50 or Target:DebuffUp(S.Deathmark) or S.Deathmark:IsReady()) or HL.BossFilteredFightRemains("<=", 15) then
+      and (S.Deathmark:CooldownRemains() >= 50 or Target:DebuffUp(S.Deathmark) or (DeathmarkCondition and S.Deathmark:IsReady())) or HL.BossFilteredFightRemains("<=", 15) then
       if Cast(S.Kingsbane, Settings.Assassination.GCDasOffGCD.Kingsbane) then
         return "Cast Kingsbane"
       end

--- a/HeroRotation_Rogue/Settings.lua
+++ b/HeroRotation_Rogue/Settings.lua
@@ -73,12 +73,12 @@ HR.GUISettings.APL.Rogue = {
     },
     OffGCDasOffGCD = {
       Deathmark = true,
-      IndiscriminateCarnage = true,
     },
     StealthMacro = {
       Vanish = true,
       Shadowmeld = true
-    }
+    },
+    ShowIndiscriminateCarnageOnMainIcon = true
   },
   Outlaw = {
     -- Roll the Bones Logic, accepts "SimC", "1+ Buff" and every "RtBName".
@@ -159,6 +159,7 @@ CreatePanelOption("Slider", CP_Assassination, "APL.Rogue.Assassination.MutilateD
 CreatePanelOption("Dropdown", CP_Assassination, "APL.Rogue.Assassination.UsePriorityRotation", { "Never", "On Bosses", "Always", "Auto" }, "Use Priority Rotation", "Select when to show rotation for maximum priority damage (at the cost of overall AoE damage.)\nAuto will function as Never except on specific encounters where AoE is not recommended.")
 CreatePanelOption("CheckButton", CP_Assassination, "APL.Rogue.Assassination.StealthMacro.Vanish", "Stealth Combo - Vanish", "Allow suggesting Vanish stealth ability combos (recommended)")
 CreatePanelOption("CheckButton", CP_Assassination, "APL.Rogue.Assassination.StealthMacro.Shadowmeld", "Stealth Combo - Shadowmeld", "Allow suggesting Shadowmeld stealth ability combos (recommended)")
+CreatePanelOption("CheckButton", CP_Assassination, "APL.Rogue.Assassination.ShowIndiscriminateCarnageOnMainIcon", "Indiscriminate Carnage - Main Icon", "Show casts for indiscriminate carnage on the main icon (main target)")
 CreateARPanelOptions(CP_Assassination, "APL.Rogue.Assassination")
 
 -- Outlaw


### PR DESCRIPTION
Added options to toggle rupture and garrote spreading via indiscriminate carnage to be shown on the main icon;

tied kingsbane back into deathmarks condition when suggesting in parallel when both are off gcd so kingsbane won't be suggested before deathmark when both are ready;