### PR TITLE
Anniversary Update updates and bug workarounds

### DIFF
--- a/HeroRotation_DemonHunter/DemonHunter.lua
+++ b/HeroRotation_DemonHunter/DemonHunter.lua
@@ -70,6 +70,7 @@ Spell.DemonHunter.AldrachiReaver = {
   GlaiveFlurryBuff                      = Spell(442435),
   ThrilloftheFightAtkBuff               = Spell(442695),
   ThrilloftheFightDmgBuff               = Spell(442688),
+  WarbladesHungerBuff                   = Spell(442503),
   -- Debuffs
   ReaversMarkDebuff                     = Spell(442624),
   RendingStrikeBuff                     = Spell(442442),


### PR DESCRIPTION
* (APL) Adds `WarbladesHungerBuff` tracking
* (APL) Additional fracture condition based on `WarbladesHungerBuff`
* (APL) Remove `UseRGHunt` as it was adding complexity for no gain
* (HR optimization) Handle an edge-case where a player could get stuck in `RGSequence()` with nothing recommended
* (HR workaround) Temporarily override The Hunt's icon with a `CastAnnotated` because blizzard broke the icon

@Cilraaz you may want to check my work on `CastAnnotated` changes. Seems to work okay in-game, but there may be a clearer way to indicate this other than with the "pool" icon.