### PR TITLE
[Monk] Add Mistweaver DPS Profile Support

### DIFF
--- a/HeroRotation/Main.lua
+++ b/HeroRotation/Main.lua
@@ -355,7 +355,7 @@ local EnabledRotation = {
   -- Monk
   [268]   = "HeroRotation_Monk",          -- Brewmaster
   [269]   = "HeroRotation_Monk",          -- Windwalker
-  --[270]   = "HeroRotation_Monk",          -- Mistweaver
+  [270]   = "HeroRotation_Monk",          -- Mistweaver
   -- Paladin
   --[65]    = "HeroRotation_Paladin",       -- Holy
   [66]    = "HeroRotation_Paladin",       -- Protection

--- a/HeroRotation_Mage/Settings.lua
+++ b/HeroRotation_Mage/Settings.lua
@@ -17,7 +17,6 @@ local CreateARPanelOptions = HR.GUI.CreateARPanelOptions
 -- All settings here should be moved into the GUI someday.
 HR.GUISettings.APL.Mage = {
   Commons = {
-    UseTemporalWarp = true,
     Enabled = {
       Potions = true,
       Trinkets = true,
@@ -26,27 +25,25 @@ HR.GUISettings.APL.Mage = {
   },
   CommonsDS = {
     DisplayStyle = {
-      -- Common
       Interrupts = "Cooldown",
       Items = "Suggested",
       Potions = "Suggested",
       Trinkets = "Suggested",
-      -- Class Specific
-      ShiftingPower = "Suggested",
     },
   },
   CommonsOGCD = {
-    -- {Display GCD as OffGCD}
-    GCDasOffGCD = {
-      -- Abilities
-      ArcaneIntellect = true,
-    },
-    -- {Display OffGCD as OffGCD}
-    OffGCDasOffGCD = {
-      -- Racials
+    Enabled = {
       Racials = true,
-      -- Abilities
-      TimeWarp = true,
+      Items = true,
+      Trinkets = true,
+    },
+    Settings = {
+      GCDasOffGCD = {
+        ArcaneIntellect = true,
+      },
+      OffGCDasOffGCD = {
+        TimeWarp = true,
+      }
     }
   },
   Arcane = {

--- a/HeroRotation_Monk/HeroRotation_Monk.toc
+++ b/HeroRotation_Monk/HeroRotation_Monk.toc
@@ -13,4 +13,5 @@ Monk.lua
 Events.lua
 Brewmaster.lua
 Windwalker.lua
+Mistweaver.lua
 Overrides.lua

--- a/HeroRotation_Monk/Mistweaver.lua
+++ b/HeroRotation_Monk/Mistweaver.lua
@@ -21,6 +21,7 @@ local Item      = HL.Item
 -- HeroRotation
 local HR        = HeroRotation
 local Cast      = HR.Cast
+local CastAnnotated = HR.CastAnnotated
 local AoEON     = HR.AoEON
 local CDsON     = HR.CDsON
 
@@ -49,6 +50,22 @@ S.AncientTeachings         = Spell(388023)
 S.CracklingJadeLightning   = Spell(117952)
 S.JadeEmpowermentBuff      = Spell(467317)
 S.RushingJadeWind          = Spell(116847)
+S.InvokeChiJiBuff          = Spell(343820)
+S.RisingMistTalent         = Spell(274909)
+S.EnvelopingBreathBuff     = Spell(343819)  -- Chi-Ji proc for instant cast
+S.EnvelopingMist           = Spell(124682)
+S.ExpelHarm                = Spell(322101)
+S.RenewingMist           = Spell(115151)
+S.ThunderFocusTea        = Spell(116680)
+S.EssenceFont            = Spell(191837)
+S.Revival                = Spell(115310)
+S.LifeCocoon            = Spell(116849)
+S.SoothingMist          = Spell(115175)
+S.Vivify                = Spell(116670)
+S.InstantVivifyBuff     = Spell(392883)     -- Various procs for instant Vivify
+S.ThunderFocusTeaBuff  = Spell(116680)   -- TFT buff for instant/enhanced spells
+S.TeaOfSerenityBuff     = Spell(388518)    -- Tea of Serenity buff
+S.VivifyBuff             = Spell(116670)           -- Vivify buff
 
 -- Items
 local I = Item.Monk.Mistweaver
@@ -67,8 +84,8 @@ local Everyone = HR.Commons.Everyone
 local Settings = {
   General = HR.GUISettings.General,
   Commons = HR.GUISettings.APL.Monk.Commons,
-  CommonsOGCD = HR.GUISettings.APL.Monk.CommonsOGCD,
   CommonsDS = HR.GUISettings.APL.Monk.CommonsDS,
+  CommonsOGCD = HR.GUISettings.APL.Monk.CommonsOGCD,
   Mistweaver = HR.GUISettings.APL.Monk.Mistweaver
 }
 
@@ -84,15 +101,51 @@ local function CanChannelCJL()
   return isReady and notMoving and inRange and hasEnergy and notChanneling
 end
 
+-- Helper function to check optimal Expel Harm conditions
+local function ShouldUseExpelHarm()
+  -- Emergency usage based on HP threshold
+  if Player:HealthPercentage() <= Settings.Mistweaver.ExpelHarmHP then
+    return true
+  end
+
+  -- Optimal damage transfer conditions
+  local hasEnvelopingMist = Player:BuffUp(S.EnvelopingMistBuff)
+  local hasRenewingMist = Player:BuffUp(S.RenewingMistBuff)
+  local hasChiHarmony = Player:BuffUp(S.ChiHarmonyBuff)
+  local hasTFT = S.ThunderFocusTea:IsReady()
+
+  -- Best case: All buffs + TFT available
+  if hasEnvelopingMist and hasRenewingMist and hasChiHarmony and hasTFT then
+    return true, true  -- Second return indicates TFT usage
+  end
+
+  -- Good case: All required buffs without TFT
+  if hasEnvelopingMist and hasRenewingMist and hasChiHarmony then
+    return true, false
+  end
+
+  return false
+end
+
+-- Helper function for instant heals that should show on left
+local function HealLeft(spell, displayStyle)
+  return HR.CastLeft(spell, displayStyle) 
+end
+
+-- Helper function for regular healing casts
+local function Heal(spell, displayStyle)
+  return HR.Cast(spell, displayStyle)
+end
+
 -- Add this function before APL()
 local function Precombat()
-  -- Snapshot stats and use consumables
-  if Settings.Commons.Enabled.Potions then
-    local PotionSelected = Everyone.PotionSelected()
-    if PotionSelected and PotionSelected:IsReady() then
-      if Cast(PotionSelected, nil, Settings.CommonsDS.DisplayStyle.Potions) then return "potion precombat"; end
-    end
-  end
+  -- Remove potion check
+  -- if Settings.Commons.Enabled.Potions then
+  --   local PotionSelected = Everyone.PotionSelected(Settings.Mistweaver.PotionType.Selected)
+  --   if PotionSelected and PotionSelected:IsReady() then
+  --     if Cast(PotionSelected, Settings.CommonsDS.DisplayStyle.Potions) then return "potion precombat"; end
+  --   end
+  -- end
 
   -- Racial abilities pre-combat
   if S.BloodFury:IsCastable() then
@@ -117,190 +170,49 @@ local function Precombat()
   return
 end
 
-local function PureDPSPriority()  -- Used when CDs ON - Maximum damage
-  -- Crackling Jade Lightning with Jade Empowerment
-  -- Only used in AoE (4+ targets) when empowered by Thunder Focus Tea
-  -- Each Jade Empowerment stack is a separate use, not a power increase
-  if S.CracklingJadeLightning:IsReady() and Player:BuffUp(S.JadeEmpowermentBuff) and EnemiesCount5 >= 4 then
-    if Cast(S.CracklingJadeLightning, nil, nil, not Target:IsSpellInRange(S.CracklingJadeLightning)) then 
-      return "crackling_jade_lightning empowered aoe"; 
+local function FistweavingPriority()
+  -- Track what we want to show in each window
+  local mainIcon, leftIcon = nil, nil
+
+  -- Cooldowns first
+  if CDsON() then
+    if S.ThunderFocusTea:IsReady() then
+      if Cast(S.ThunderFocusTea, Settings.Mistweaver.DisplayStyle.ThunderFocusTea) then 
+        return "thunder_focus_tea cd"; 
+      end
+    end
+    
+    if S.InvokeChiJi:IsReady() then
+      if Cast(S.InvokeChiJi, Settings.Mistweaver.DisplayStyle.InvokeChiJi) then 
+        return "invoke_chiji cd"; 
+      end
     end
   end
 
-  -- Thunder Focus Tea optimization
-  -- Used primarily for RSK cooldown reduction in pure DPS
-  -- Also provides Jade Empowerment for AoE situations
-  if S.ThunderFocusTea:IsReady() then
-    if S.RisingSunKick:CooldownRemains() > 9 
-       and (not Player:BuffUp(S.RenewingMistBuff) or Player:BuffRemains(S.RenewingMistBuff) > 8)
-       and (not S.SecretInfusion:IsAvailable() or Player:HasTier(31, 2)) then
-      if Cast(S.ThunderFocusTea, Settings.Mistweaver.OffGCDasOffGCD.ThunderFocusTea) then return "thunder_focus_tea for_rsk"; end
-    end
+  -- Check instant heal procs for left icon (like Fire Blast)
+  if S.EnvelopingMist:IsReady() and Player:BuffUp(S.EnvelopingBreathBuff) then
+    leftIcon = {S.EnvelopingMist, Settings.Mistweaver.DisplayStyle.InstantEnvelopingMist, "instant_enveloping_mist left"}
+  elseif S.RenewingMist:IsReady() and S.RenewingMist:Charges() > 0 then
+    leftIcon = {S.RenewingMist, Settings.Mistweaver.DisplayStyle.RenewingMist, "renewing_mist left"}
+  elseif S.Vivify:IsReady() and (Player:BuffUp(S.TeaOfSerenityBuff) or Player:BuffUp(S.ThunderFocusTeaBuff)) then
+    leftIcon = {S.Vivify, Settings.Mistweaver.DisplayStyle.InstantVivify, "instant_vivify left"}
   end
 
-  -- Invoke Chi-ji/Yu'lon
-  if S.InvokeChiJi:IsReady() and S.InvokersDelight:IsAvailable() then
-    if Cast(S.InvokeChiJi) then return "invoke_chiji pure_dps"; end
-  end
-
-  -- Celestial Conduit
-  if S.CelestialConduit:IsReady() then
-    if Cast(S.CelestialConduit) then return "celestial_conduit pure_dps"; end
-  end
-
-  -- Thunder Focus Tea + Rising Sun Kick combo
-  if S.ThunderFocusTea:IsReady() then
-    if Cast(S.ThunderFocusTea, Settings.Mistweaver.OffGCDasOffGCD.ThunderFocusTea) then return "thunder_focus_tea pure_dps"; end
-  end
-  if S.RisingSunKick:IsReady() and S.SecretInfusion:IsAvailable() and Player:BuffUp(S.ThunderFocusTeaBuff) then
-    if Cast(S.RisingSunKick) then return "rising_sun_kick pure_dps tft"; end
-  end
-
-  -- Fixed rotation without complex resets
-  -- Rising Sun Kick on CD
+  -- Check DPS abilities for main icon
   if S.RisingSunKick:IsReady() then
-    if Cast(S.RisingSunKick, nil, nil, not Target:IsInMeleeRange(5)) then return "rising_sun_kick pure_dps"; end
+    mainIcon = {S.RisingSunKick, nil, "rising_sun_kick main"}
+  elseif S.BlackoutKick:IsReady() then
+    mainIcon = {S.BlackoutKick, nil, "blackout_kick main"}
+  elseif S.TigerPalm:IsReady() then
+    mainIcon = {S.TigerPalm, nil, "tiger_palm main"}
   end
 
-  -- Touch of Death
-  if S.TouchofDeath:IsReady() then
-    if Cast(S.TouchofDeath, nil, nil, not Target:IsInMeleeRange(5)) then return "touch_of_death pure_dps"; end
+  -- Cast both main and left if available
+  if leftIcon then
+    if HealLeft(leftIcon[1], leftIcon[2]) then return leftIcon[3]; end
   end
-
-  -- Chi Wave
-  if S.ChiWave:IsReady() then
-    if Cast(S.ChiWave, nil, nil, not Target:IsInRange(40)) then return "chi_wave pure_dps"; end
-  end
-
-  -- Jadefire Stomp
-  if S.JadefireStomp:IsReady() then
-    if Cast(S.JadefireStomp, nil, nil, not Target:IsInRange(30)) then return "jadefire_stomp pure_dps"; end
-  end
-
-  -- Simple 4-stack Blackout Kick usage
-  if S.BlackoutKick:IsReady() and Player:BuffStack(S.TeachingsoftheMonasteryBuff) >= 4 then
-    if Cast(S.BlackoutKick, nil, nil, not Target:IsInMeleeRange(5)) then return "blackout_kick pure_dps"; end
-  end
-
-  -- Tiger Palm to build stacks
-  if S.TigerPalm:IsReady() and Player:BuffStack(S.TeachingsoftheMonasteryBuff) < 4 then
-    if Cast(S.TigerPalm, nil, nil, not Target:IsInMeleeRange(5)) then return "tiger_palm pure_dps"; end
-  end
-
-  -- Jadefire Stomp for buffs
-  if S.JadefireStomp:IsReady() and (Player:BuffDown(S.AncientConcordanceBuff) or Player:BuffDown(S.AwakenedJadefireBuff)) then
-    if Cast(S.JadefireStomp, nil, nil, not Target:IsInRange(30)) then return "jadefire_stomp pure_dps"; end
-  end
-
-  -- Chi Burst in AoE
-  if S.ChiBurst:IsReady() and not Player:IsMoving() and EnemiesCount5 >= 2 then
-    if Cast(S.ChiBurst, nil, nil, not Target:IsInRange(40)) then return "chi_burst aoe pure_dps"; end
-  end
-
-  -- Spinning Crane Kick in AoE
-  if S.SpinningCraneKick:IsReady() and (EnemiesCount5 >= 4 or Player:BuffUp(S.DanceofChijiBuff)) then
-    if Cast(S.SpinningCraneKick) then return "spinning_crane_kick aoe pure_dps"; end
-  end
-
-  -- Rushing Jade Wind
-  if S.RushingJadeWind:IsReady() then
-    if Cast(S.RushingJadeWind) then return "rushing_jade_wind pure_dps"; end
-  end
-
-  return false
-end
-
-local function FistweavingPriority()  -- Used when CDs OFF - Optimized for DPS healing
-  -- When Chi-ji is active, optimize kick usage for stacks
-  if Player:BuffUp(S.InvokeChiJiBuff) then
-    -- Rising Sun Kick priority remains high
-    if S.RisingSunKick:IsReady() then
-      if Cast(S.RisingSunKick, nil, nil, not Target:IsInMeleeRange(5)) then return "rising_sun_kick chiji"; end
-    end
-
-    -- Blackout Kick usage during Chi-ji
-    -- Only stack to 2 for optimal bird stack generation
-    if S.BlackoutKick:IsReady() then
-      local tomStacks = Player:BuffStack(S.TeachingsoftheMonasteryBuff)
-      if tomStacks <= 2 then
-        if Cast(S.BlackoutKick, nil, nil, not Target:IsInMeleeRange(5)) then return "blackout_kick chiji"; end
-      end
-    end
-
-    -- Tiger Palm during Chi-ji - only build to 2 stacks
-    if S.TigerPalm:IsReady() and Player:BuffStack(S.TeachingsoftheMonasteryBuff) < 2 then
-      if Cast(S.TigerPalm, nil, nil, not Target:IsInMeleeRange(5)) then return "tiger_palm chiji"; end
-    end
-
-    -- Spinning Crane Kick during Chi-ji for additional stacks
-    if S.SpinningCraneKick:IsReady() and EnemiesCount5 >= 3 then
-      if Cast(S.SpinningCraneKick) then return "spinning_crane_kick chiji"; end
-    end
-  end
-
-  -- Touch of Death - Highest priority
-  -- Important for both burst damage and healing through Ancient Teachings
-  if S.TouchofDeath:IsReady() then
-    if Cast(S.TouchofDeath, nil, nil, not Target:IsInMeleeRange(5)) then return "touch_of_death fistweave"; end
-  end
-
-  -- Rising Sun Kick priority
-  -- Core ability for both damage and healing:
-  -- 1. Extends Renewing Mist duration
-  -- 2. Triggers Ancient Teachings healing
-  -- 3. Core damage ability
-  if S.RisingSunKick:IsReady() then
-    if Cast(S.RisingSunKick, nil, nil, not Target:IsInMeleeRange(5)) then return "rising_sun_kick fistweave"; end
-  end
-
-  -- Blackout Kick for RSK resets
-  -- Important to track stacks and cooldown timing
-  -- Used to maintain healing through damage and reset RSK
-  if S.BlackoutKick:IsReady() then
-    local rskCD = S.RisingSunKick:CooldownRemains()
-    local tomStacks = Player:BuffStack(S.TeachingsoftheMonasteryBuff)
-    if (tomStacks >= 3 and rskCD > 3) or (rskCD > Player:GCD() * 2) then
-      if Cast(S.BlackoutKick, nil, nil, not Target:IsInMeleeRange(5)) then 
-        if S.RisingSunKick:IsReady() then
-          if Cast(S.RisingSunKick, nil, nil, not Target:IsInMeleeRange(5)) then return "rising_sun_kick fistweave reset"; end
-        end
-        return "blackout_kick fistweave"; 
-      end
-    end
-  end
-
-  -- Tiger Palm for RSK resets and stack building
-  if S.TigerPalm:IsReady() then
-    local rskCD = S.RisingSunKick:CooldownRemains()
-    if Player:BuffStack(S.TeachingsoftheMonasteryBuff) < 3 or rskCD > Player:GCD() then
-      if Cast(S.TigerPalm, nil, nil, not Target:IsInMeleeRange(5)) then 
-        if S.RisingSunKick:IsReady() then
-          if Cast(S.RisingSunKick, nil, nil, not Target:IsInMeleeRange(5)) then return "rising_sun_kick fistweave reset"; end
-        end
-        return "tiger_palm fistweave"; 
-      end
-    end
-  end
-
-  -- Lower priority abilities
-  -- Jadefire Stomp for buffs
-  if S.JadefireStomp:IsReady() and (Player:BuffDown(S.AncientConcordanceBuff) or Player:BuffDown(S.AwakenedJadefireBuff)) then
-    if Cast(S.JadefireStomp, nil, nil, not Target:IsInRange(30)) then return "jadefire_stomp fistweave"; end
-  end
-
-  -- Chi Burst for AoE healing/damage
-  if S.ChiBurst:IsReady() and not Player:IsMoving() and EnemiesCount5 >= 2 then
-    if Cast(S.ChiBurst, nil, nil, not Target:IsInRange(40)) then return "chi_burst aoe"; end
-  end
-
-  -- Rushing Jade Wind
-  if S.RushingJadeWind:IsReady() then
-    if Cast(S.RushingJadeWind) then return "rushing_jade_wind fistweave"; end
-  end
-
-  -- Spinning Crane Kick only in heavy AoE situations
-  if S.SpinningCraneKick:IsReady() and EnemiesCount5 >= 5 then
-    if Cast(S.SpinningCraneKick) then return "spinning_crane_kick aoe"; end
+  if mainIcon then
+    if Cast(mainIcon[1], nil, nil, not Target:IsInMeleeRange(5)) then return mainIcon[3]; end
   end
 
   return false
@@ -324,23 +236,36 @@ local function APL()
   -- Main Combat Rotation
   if Everyone.TargetIsValid() then
     -- Interrupts
-    if Everyone.Interrupt(S.SpearHandStrike, Settings.CommonsOGCD.OffGCDasOffGCD.SpearHandStrike, false) then return "spear hand strike"; end
+    if Everyone.Interrupt(S.SpearHandStrike, Settings.CommonsDS.DisplayStyle.Interrupts, false) then 
+      return "spear hand strike"; 
+    end
 
-    -- Choose priority based on CDs toggle
+    -- Major Cooldowns (controlled by CD toggle)
     if CDsON() then
-      local ShouldReturn = PureDPSPriority(); if ShouldReturn then return ShouldReturn; end
-    else
-      local ShouldReturn = FistweavingPriority(); if ShouldReturn then return ShouldReturn; end
+      -- Thunder Focus Tea
+      if S.ThunderFocusTea:IsReady() then
+        if Cast(S.ThunderFocusTea, Settings.Mistweaver.DisplayStyle.ThunderFocusTea) then 
+          return "thunder_focus_tea cd"; 
+        end
+      end
+
+      -- Celestial Conduit
+      if S.CelestialConduit:IsReady() then
+        if Cast(S.CelestialConduit, Settings.Mistweaver.DisplayStyle.CelestialConduit) then 
+          return "celestial_conduit cd"; 
+        end
+      end
     end
 
-    -- Shared low priority abilities regardless of mode
-    -- Expel Harm when buffs align
-    if S.ExpelHarm:IsReady() and (not Settings.Mistweaver.RequireExpelHarmBuffs or 
-      (Player:BuffUp(S.EnvelopingMistBuff) and Player:BuffUp(S.RenewingMistBuff) and Player:BuffUp(S.ChiHarmonyBuff))) then
-      if Cast(S.ExpelHarm, nil, nil, not Target:IsInRange(20)) then return "expel_harm"; end
+    -- Invoke Chi-ji (Red Crane) - Used on CD regardless of CD toggle
+    if S.InvokeChiJi:IsReady() then
+      if Cast(S.InvokeChiJi, Settings.Mistweaver.DisplayStyle.InvokeChiJi) then 
+        return "invoke_chiji"; 
+      end
     end
 
-    -- Remove ranged CJL usage to save it for empowered AoE only
+    -- Regular rotation (former FistweavingPriority)
+    local ShouldReturn = FistweavingPriority(); if ShouldReturn then return ShouldReturn; end
   end
 end
 
@@ -349,10 +274,15 @@ local function Init()
   S.CracklingJadeLightning:RegisterInFlight()
   S.CracklingJadeLightning:RegisterInFlightEffect(117952)
   
-  -- Register buff tracking
-  S.JadeEmpowermentBuff:RegisterAuraTracking()
-  S.TeachingsoftheMonasteryBuff:RegisterAuraTracking()
+  -- Register buff tracking - only register spells that exist
+  if S.JadeEmpowermentBuff then S.JadeEmpowermentBuff:RegisterAuraTracking() end
+  if S.TeachingsoftheMonasteryBuff then S.TeachingsoftheMonasteryBuff:RegisterAuraTracking() end
+  if S.EnvelopingBreathBuff then S.EnvelopingBreathBuff:RegisterAuraTracking() end
+  if S.ThunderFocusTeaBuff then S.ThunderFocusTeaBuff:RegisterAuraTracking() end
+  if S.TeaOfSerenityBuff then S.TeaOfSerenityBuff:RegisterAuraTracking() end
+  if S.VivifyBuff then S.VivifyBuff:RegisterAuraTracking() end
   
+  -- Print initialization message
   HR.Print("Mistweaver Monk rotation has been initialized")
 end
 

--- a/HeroRotation_Monk/Mistweaver.lua
+++ b/HeroRotation_Monk/Mistweaver.lua
@@ -54,12 +54,17 @@ local Settings = {
 
 -- Add this function before APL()
 local function Precombat()
-  -- Potion
+  -- Snapshot stats and use consumables
   if Settings.Commons.Enabled.Potions then
     local PotionSelected = Everyone.PotionSelected()
     if PotionSelected and PotionSelected:IsReady() then
       if Cast(PotionSelected, nil, Settings.CommonsDS.DisplayStyle.Potions) then return "potion precombat"; end
     end
+  end
+
+  -- Racial abilities pre-combat
+  if S.BloodFury:IsCastable() then
+    if Cast(S.BloodFury, Settings.Commons.OffGCDasOffGCD.Racials) then return "blood_fury precombat"; end
   end
 
   -- Chi Burst - Valuable pre-pull for both healing and damage
@@ -82,6 +87,27 @@ local function Precombat()
 end
 
 local function PureDPSPriority()  -- Used when CDs ON - Maximum damage
+  -- Invoke Chi-ji/Yu'lon
+  if S.InvokeChiJi:IsReady() and S.InvokersDelight:IsAvailable() then
+    if Cast(S.InvokeChiJi) then return "invoke_chiji pure_dps"; end
+  end
+  if S.InvokeYulon:IsReady() and S.InvokersDelight:IsAvailable() then
+    if Cast(S.InvokeYulon) then return "invoke_yulon pure_dps"; end
+  end
+
+  -- Celestial Conduit
+  if S.CelestialConduit:IsReady() then
+    if Cast(S.CelestialConduit) then return "celestial_conduit pure_dps"; end
+  end
+
+  -- Thunder Focus Tea + Rising Sun Kick combo
+  if S.ThunderFocusTea:IsReady() then
+    if Cast(S.ThunderFocusTea, Settings.Mistweaver.OffGCDasOffGCD.ThunderFocusTea) then return "thunder_focus_tea pure_dps"; end
+  end
+  if S.RisingSunKick:IsReady() and S.SecretInfusion:IsAvailable() and Player:BuffUp(S.ThunderFocusTeaBuff) then
+    if Cast(S.RisingSunKick) then return "rising_sun_kick pure_dps tft"; end
+  end
+
   -- Fixed rotation without complex resets
   -- Rising Sun Kick on CD
   if S.RisingSunKick:IsReady() then
@@ -117,6 +143,23 @@ local function PureDPSPriority()  -- Used when CDs ON - Maximum damage
 end
 
 local function FistweavingPriority()  -- Used when CDs OFF - Normal fistweaving
+  -- Dance of Chi-ji proc
+  if S.SpinningCraneKick:IsReady() and Player:BuffUp(S.DanceofChijiBuff) then
+    if Cast(S.SpinningCraneKick) then return "spinning_crane_kick dance_proc"; end
+  end
+
+  -- Chi Burst in AoE
+  if S.ChiBurst:IsReady() and not Player:IsMoving() and EnemiesCount5 >= 2 then
+    if Cast(S.ChiBurst) then return "chi_burst aoe"; end
+  end
+
+  -- Jadefire Stomp logic
+  if S.JadefireStomp:IsReady() then
+    if (EnemiesCount5 >= 4 and EnemiesCount5 <= 10) or Player:BuffDown(S.JadefireStompBuff) then
+      if Cast(S.JadefireStomp) then return "jadefire_stomp"; end
+    end
+  end
+
   -- Rising Sun Kick - Core ability for HoT extension and Crane Style healing
   -- Extends Renewing Mist duration and provides passive healing
   if S.RisingSunKick:IsReady() then

--- a/HeroRotation_Monk/Mistweaver.lua
+++ b/HeroRotation_Monk/Mistweaver.lua
@@ -37,6 +37,12 @@ S.SecretInfusion         = Spell(388491)
 S.ThunderFocusTeaBuff    = Spell(116680)
 S.DanceofChijiBuff       = Spell(325202)
 S.JadefireStompBuff      = Spell(388663)
+S.RisingMist              = Spell(274909)
+S.RenewingMistBuff       = Spell(119611)
+S.TeachingsoftheMonasteryBuff = Spell(202090)
+S.JadeFireTeachings      = Spell(388023)
+S.CraneStyle             = Spell(383999)
+S.PoolofMists            = Spell(388477)
 
 -- Items
 local I = Item.Monk.Mistweaver
@@ -75,9 +81,8 @@ local function Precombat()
     if Cast(S.BloodFury, Settings.Commons.OffGCDasOffGCD.Racials) then return "blood_fury precombat"; end
   end
 
-  -- Chi Burst - Valuable pre-pull for both healing and damage
-  -- Try to hit multiple targets if possible
-  if S.ChiBurst:IsCastable() and not Player:IsMoving() and EnemiesCount5 >= 3 then
+  -- Chi Burst - Single target pre-pull
+  if S.ChiBurst:IsReady() and not Player:IsMoving() then
     if Cast(S.ChiBurst, nil, nil, not Target:IsInRange(40)) then return "chi_burst precombat"; end
   end
 
@@ -150,67 +155,89 @@ local function PureDPSPriority()  -- Used when CDs ON - Maximum damage
   return false
 end
 
-local function FistweavingPriority()  -- Used when CDs OFF - Normal fistweaving
-  -- Dance of Chi-ji proc
-  if S.SpinningCraneKick:IsReady() and Player:BuffUp(S.DanceofChijiBuff) then
-    if Cast(S.SpinningCraneKick) then return "spinning_crane_kick dance_proc"; end
+local function FistweavingPriority()  -- Used when CDs OFF - Optimized for DPS healing
+  -- Touch of Death - Highest priority for Fatal Touch effects
+  if S.TouchofDeath:IsReady() then
+    if Cast(S.TouchofDeath, nil, nil, not Target:IsInMeleeRange(5)) then return "touch_of_death fistweave"; end
   end
 
-  -- Chi Burst in AoE
-  if S.ChiBurst:IsReady() and not Player:IsMoving() and EnemiesCount5 >= 2 then
-    if Cast(S.ChiBurst) then return "chi_burst aoe"; end
-  end
-
-  -- Jadefire Stomp logic
-  if S.JadefireStomp:IsReady() then
-    if (EnemiesCount5 >= 4 and EnemiesCount5 <= 10) or Player:BuffDown(S.JadefireStompBuff) then
-      if Cast(S.JadefireStomp) then return "jadefire_stomp"; end
-    end
-  end
-
-  -- Rising Sun Kick - Core ability for HoT extension and Crane Style healing
-  -- Extends Renewing Mist duration and provides passive healing
+  -- Rising Sun Kick priority
+  -- Core ability for damage and healing through various talents
   if S.RisingSunKick:IsReady() then
     if Cast(S.RisingSunKick, nil, nil, not Target:IsInMeleeRange(5)) then return "rising_sun_kick fistweave"; end
   end
 
-  -- Chi Burst - Strong AoE healing/damage if can hit multiple allies
-  if S.ChiBurst:IsReady() and not Player:IsMoving() and EnemiesCount5 >= 3 then
-    if Cast(S.ChiBurst, nil, nil, not Target:IsInRange(40)) then return "chi_burst fistweave"; end
+  -- Thunder Focus Tea optimization
+  -- Use with RSK if conditions align, otherwise save for Renewing Mist
+  if S.ThunderFocusTea:IsReady() then
+    -- Use with RSK if:
+    -- 1. RSK cooldown is significant (>9s)
+    -- 2. We don't need to save it for Renewing Mist
+    -- 3. Secret Infusion talent consideration
+    if S.RisingSunKick:CooldownRemains() > 9 
+       and (not Player:BuffUp(S.RenewingMistBuff) or Player:BuffRemains(S.RenewingMistBuff) > 8)
+       and (not S.SecretInfusion:IsAvailable() or Player:HasTier(31, 2)) then
+      if Cast(S.ThunderFocusTea, Settings.Mistweaver.OffGCDasOffGCD.ThunderFocusTea) then return "thunder_focus_tea for_rsk"; end
+    end
   end
 
-  -- Chi Wave - Consistent healing that bounces between allies and enemies
-  if S.ChiWave:IsReady() then
-    if Cast(S.ChiWave, nil, nil, not Target:IsInRange(40)) then return "chi_wave fistweave"; end
+  -- Expel Harm with buff conditions
+  if S.ExpelHarm:IsReady() and Player:BuffUp(S.EnvelopingMistBuff) 
+     and Player:BuffUp(S.RenewingMistBuff) and Player:BuffUp(S.ChiHarmonyBuff) then
+    if Cast(S.ExpelHarm, nil, nil, not Target:IsInRange(20)) then return "expel_harm fistweave"; end
   end
 
-  -- Jadefire Stomp - Maintains important healing buffs
-  -- Keep Awakened Jadefire and Jadefire Teachings active
-  if S.JadefireStomp:IsReady() then
+  -- Jadefire Stomp for buffs
+  if S.JadefireStomp:IsReady() and (Player:BuffDown(S.AncientConcordanceBuff) or Player:BuffDown(S.AwakenedJadefireBuff)) then
     if Cast(S.JadefireStomp, nil, nil, not Target:IsInRange(30)) then return "jadefire_stomp fistweave"; end
   end
 
-  -- Thunder Focus Tea - Use with healing abilities
-  if S.ThunderFocusTea:IsReady() then
-    if Cast(S.ThunderFocusTea, Settings.Mistweaver.OffGCDasOffGCD.ThunderFocusTea) then return "thunder_focus_tea fistweave"; end
+  -- Chi Burst for AoE healing/damage
+  if S.ChiBurst:IsReady() and not Player:IsMoving() and EnemiesCount5 >= 2 then
+    if Cast(S.ChiBurst, nil, nil, not Target:IsInRange(40)) then return "chi_burst aoe"; end
   end
 
-  -- Blackout Kick at 3 stacks
-  -- Each stack causes additional hits, providing more healing through Crane Style
-  if S.BlackoutKick:IsReady() and Player:BuffStack(S.TeachingsoftheMonasteryBuff) >= 3 then
-    if Cast(S.BlackoutKick, nil, nil, not Target:IsInMeleeRange(5)) then return "blackout_kick fistweave"; end
+  -- Spinning Crane Kick in AoE
+  if S.SpinningCraneKick:IsReady() and (EnemiesCount5 >= 4 or Player:BuffUp(S.DanceofChijiBuff)) then
+    if Cast(S.SpinningCraneKick) then return "spinning_crane_kick aoe"; end
   end
 
-  -- Tiger Palm to build stacks
-  -- Generates ToM stacks for enhanced healing through Blackout Kick
-  if S.TigerPalm:IsReady() and Player:BuffStack(S.TeachingsoftheMonasteryBuff) < 3 then
-    if Cast(S.TigerPalm, nil, nil, not Target:IsInMeleeRange(5)) then return "tiger_palm fistweave"; end
+  -- Optimized Blackout Kick usage
+  -- 1. Don't waste high stacks when RSK is coming off CD soon
+  -- 2. Use for RSK reset chance when appropriate
+  -- 3. Maintain healing through Crane Style/other talents
+  if S.BlackoutKick:IsReady() then
+    local rskCD = S.RisingSunKick:CooldownRemains()
+    local tomStacks = Player:BuffStack(S.TeachingsoftheMonasteryBuff)
+    -- Use high stacks when RSK isn't coming off CD soon
+    if (tomStacks >= 3 and rskCD > 3) or 
+       -- Or use for reset chance if RSK is on significant CD
+       (rskCD > Player:GCD() * 2) then
+      if Cast(S.BlackoutKick, nil, nil, not Target:IsInMeleeRange(5)) then 
+        -- Check for RSK reset
+        if S.RisingSunKick:IsReady() then
+          if Cast(S.RisingSunKick, nil, nil, not Target:IsInMeleeRange(5)) then return "rising_sun_kick fistweave reset"; end
+        end
+        return "blackout_kick fistweave"; 
+      end
+    end
   end
 
-  -- Spinning Crane Kick for AoE healing
-  -- Only use in AoE situations where the healing is valuable
-  if S.SpinningCraneKick:IsReady() and EnemiesCount5 > 4 then
-    if Cast(S.SpinningCraneKick, nil, nil, not Target:IsInMeleeRange(8)) then return "spinning_crane_kick fistweave"; end
+  -- Tiger Palm
+  -- 1. Build ToM stacks
+  -- 2. Chance to reset RSK
+  -- 3. Maintain healing through various talents
+  if S.TigerPalm:IsReady() then
+    local rskCD = S.RisingSunKick:CooldownRemains()
+    if Player:BuffStack(S.TeachingsoftheMonasteryBuff) < 3 or rskCD > Player:GCD() then
+      if Cast(S.TigerPalm, nil, nil, not Target:IsInMeleeRange(5)) then 
+        -- Check for RSK reset
+        if S.RisingSunKick:IsReady() then
+          if Cast(S.RisingSunKick, nil, nil, not Target:IsInMeleeRange(5)) then return "rising_sun_kick fistweave reset"; end
+        end
+        return "tiger_palm fistweave"; 
+      end
+    end
   end
 
   return false

--- a/HeroRotation_Monk/Mistweaver.lua
+++ b/HeroRotation_Monk/Mistweaver.lua
@@ -66,6 +66,8 @@ S.InstantVivifyBuff     = Spell(392883)     -- Various procs for instant Vivify
 S.ThunderFocusTeaBuff  = Spell(116680)   -- TFT buff for instant/enhanced spells
 S.TeaOfSerenityBuff     = Spell(388518)    -- Tea of Serenity buff
 S.VivifyBuff             = Spell(116670)           -- Vivify buff
+S.StrengthofSpirit          = Spell(443112)  -- Strength of the Black Ox buff
+S.RushingWindKick          = Spell(467307)  -- Rushing Wind Kick (replaces RSK)
 
 -- Items
 local I = Item.Monk.Mistweaver
@@ -174,10 +176,13 @@ local function FistweavingPriority()
   -- Track what we want to show in each window
   local mainIcon, leftIcon = nil, nil
 
-  -- Check instant heal procs for left icon (like Fire Blast)
+  -- Check instant heal procs for left icon
   -- Give Enveloping Mist with Chi-Ji proc highest priority, but only at 3 stacks
   if S.EnvelopingMist:IsReady() and Player:BuffUp(S.InvokeChiJiBuff) and Player:BuffStack(S.InvokeChiJiBuff) >= 3 then
     leftIcon = {S.EnvelopingMist, Settings.Mistweaver.DisplayStyle.InstantEnvelopingMist, "instant_enveloping_mist left from chiji"}
+  -- Add Strength of the Black Ox check for Enveloping Mist
+  elseif S.EnvelopingMist:IsReady() and Player:BuffUp(S.StrengthofSpirit) then
+    leftIcon = {S.EnvelopingMist, Settings.Mistweaver.DisplayStyle.InstantEnvelopingMist, "enveloping_mist left from black ox"}
   -- Then check other instant heals
   elseif S.RenewingMist:IsReady() and S.RenewingMist:Charges() > 0 then
     leftIcon = {S.RenewingMist, Settings.Mistweaver.DisplayStyle.RenewingMist, "renewing_mist left"}
@@ -186,7 +191,9 @@ local function FistweavingPriority()
   end
 
   -- Check DPS abilities for main icon
-  if S.RisingSunKick:IsReady() then
+  if S.RushingWindKick:IsReady() then  -- Check Rushing Wind Kick first
+    mainIcon = {S.RushingWindKick, nil, "rushing_wind_kick main"}
+  elseif S.RisingSunKick:IsReady() then  -- Fallback to RSK if not equipped
     mainIcon = {S.RisingSunKick, nil, "rising_sun_kick main"}
   elseif S.BlackoutKick:IsReady() then
     mainIcon = {S.BlackoutKick, nil, "blackout_kick main"}

--- a/HeroRotation_Monk/Mistweaver.lua
+++ b/HeroRotation_Monk/Mistweaver.lua
@@ -197,6 +197,21 @@ local function PureDPSPriority()  -- Used when CDs ON - Maximum damage
     if Cast(S.TigerPalm, nil, nil, not Target:IsInMeleeRange(5)) then return "tiger_palm pure_dps"; end
   end
 
+  -- Jadefire Stomp for buffs
+  if S.JadefireStomp:IsReady() and (Player:BuffDown(S.AncientConcordanceBuff) or Player:BuffDown(S.AwakenedJadefireBuff)) then
+    if Cast(S.JadefireStomp, nil, nil, not Target:IsInRange(30)) then return "jadefire_stomp pure_dps"; end
+  end
+
+  -- Chi Burst in AoE
+  if S.ChiBurst:IsReady() and not Player:IsMoving() and EnemiesCount5 >= 2 then
+    if Cast(S.ChiBurst, nil, nil, not Target:IsInRange(40)) then return "chi_burst aoe pure_dps"; end
+  end
+
+  -- Spinning Crane Kick in AoE
+  if S.SpinningCraneKick:IsReady() and (EnemiesCount5 >= 4 or Player:BuffUp(S.DanceofChijiBuff)) then
+    if Cast(S.SpinningCraneKick) then return "spinning_crane_kick aoe pure_dps"; end
+  end
+
   return false
 end
 

--- a/HeroRotation_Monk/Mistweaver.lua
+++ b/HeroRotation_Monk/Mistweaver.lua
@@ -29,6 +29,14 @@ local CDsON     = HR.CDsON
 
 -- Spells
 local S = Spell.Monk.Mistweaver
+-- Add these new spells
+S.InvokeChiJi             = Spell(325197)
+S.InvokeYulon             = Spell(322118)
+S.InvokersDelight         = Spell(388661)
+S.SecretInfusion         = Spell(388491)
+S.ThunderFocusTeaBuff    = Spell(116680)
+S.DanceofChijiBuff       = Spell(325202)
+S.JadefireStompBuff      = Spell(388663)
 
 -- Items
 local I = Item.Monk.Mistweaver

--- a/HeroRotation_Monk/Mistweaver.lua
+++ b/HeroRotation_Monk/Mistweaver.lua
@@ -116,14 +116,9 @@ end
 
 local function PureDPSPriority()  -- Used when CDs ON - Maximum damage
   -- Crackling Jade Lightning with Jade Empowerment - Only in AoE 4+ targets
-  -- Wait for 3 stacks in AoE for maximum chain damage
   if S.CracklingJadeLightning:IsReady() and Player:BuffUp(S.JadeEmpowermentBuff) and EnemiesCount5 >= 4 then
-    local jeStacks = Player:BuffStack(S.JadeEmpowermentBuff)
-    -- Use at 3 stacks for maximum damage, or at any stack if buff is about to expire
-    if jeStacks == 3 or Player:BuffRemains(S.JadeEmpowermentBuff) < 2 then
-      if Cast(S.CracklingJadeLightning, nil, nil, not Target:IsSpellInRange(S.CracklingJadeLightning)) then 
-        return "crackling_jade_lightning empowered aoe " .. jeStacks .. " stacks"; 
-      end
+    if Cast(S.CracklingJadeLightning, nil, nil, not Target:IsSpellInRange(S.CracklingJadeLightning)) then 
+      return "crackling_jade_lightning empowered aoe"; 
     end
   end
 

--- a/HeroRotation_Monk/Mistweaver.lua
+++ b/HeroRotation_Monk/Mistweaver.lua
@@ -1,0 +1,161 @@
+--- ============================ HEADER ============================
+--- ======= LOCALIZE =======
+-- Addon
+local addonName, addonTable = ...
+-- HeroDBC
+local DBC = HeroDBC.DBC
+-- HeroLib
+local HL         = HeroLib
+local Cache      = HeroCache
+local Unit      = HL.Unit
+local Player    = Unit.Player
+local Target    = Unit.Target
+local Spell     = HL.Spell
+local Item      = HL.Item
+-- HeroRotation
+local HR        = HeroRotation
+local Cast      = HR.Cast
+local AoEON     = HR.AoEON
+local CDsON     = HR.CDsON
+
+--- ============================ CONTENT ===========================
+--- ======= APL LOCALS =======
+-- luacheck: max_line_length 9999
+
+-- Spells
+local S = Spell.Monk.Mistweaver
+
+-- Items
+local I = Item.Monk.Mistweaver
+
+-- Create table to exclude above trinkets from On Use function
+local OnUseExcludes = {
+  -- Trinkets
+}
+
+-- Rotation Var
+local Enemies5y
+local EnemiesCount5
+
+-- GUI Settings
+local Everyone = HR.Commons.Everyone
+local Settings = {
+  General = HR.GUISettings.General,
+  Commons = HR.GUISettings.APL.Monk.Commons,
+  CommonsOGCD = HR.GUISettings.APL.Monk.CommonsOGCD,
+  CommonsDS = HR.GUISettings.APL.Monk.CommonsDS,
+  Mistweaver = HR.GUISettings.APL.Monk.Mistweaver
+}
+
+-- Add this function before APL()
+local function Precombat()
+  -- Potion
+  if Settings.Commons.Enabled.Potions then
+    local PotionSelected = Everyone.PotionSelected()
+    if PotionSelected and PotionSelected:IsReady() then
+      if Cast(PotionSelected, nil, Settings.CommonsDS.DisplayStyle.Potions) then return "potion precombat"; end
+    end
+  end
+
+  -- Chi Burst
+  if S.ChiBurst:IsCastable() and not Player:IsMoving() then
+    if Cast(S.ChiBurst, nil, nil, not Target:IsInRange(40)) then return "chi_burst precombat"; end
+  end
+
+  -- Chi Wave
+  if S.ChiWave:IsCastable() then
+    if Cast(S.ChiWave, nil, nil, not Target:IsInRange(40)) then return "chi_wave precombat"; end
+  end
+
+  -- Jadefire Stomp
+  if S.JadefireStomp:IsReady() then
+    if Cast(S.JadefireStomp, nil, nil, not Target:IsInRange(30)) then return "jadefire_stomp precombat"; end
+  end
+
+  return
+end
+
+local function APL()
+  -- Unit Update
+  Enemies5y = Player:GetEnemiesInMeleeRange(5)
+  if AoEON() then
+    EnemiesCount5 = #Enemies5y
+  else 
+    EnemiesCount5 = 1
+  end
+
+  -- Out of Combat
+  if not Player:AffectingCombat() then
+    local ShouldReturn = Precombat(); if ShouldReturn then return ShouldReturn; end
+    return
+  end
+
+  -- In Combat
+  if Everyone.TargetIsValid() then
+    -- Interrupts
+    if Everyone.Interrupt(S.SpearHandStrike, Settings.CommonsOGCD.OffGCDasOffGCD.SpearHandStrike, false) then return "spear hand strike"; end
+
+    -- Touch of Death
+    if S.TouchofDeath:IsReady() then
+      if Cast(S.TouchofDeath, nil, nil, not Target:IsInMeleeRange(5)) then return "touch_of_death"; end
+    end
+
+    -- Thunder Focus Tea (if CDs are enabled)
+    if CDsON() and Settings.Mistweaver.ThunderFocusTeaWithExpelHarm and S.ThunderFocusTea:IsReady() and (S.ExpelHarm:IsReady() or S.ExpelHarm:CooldownRemains() < 2) then
+      if Cast(S.ThunderFocusTea, Settings.Mistweaver.OffGCDasOffGCD.ThunderFocusTea) then return "thunder_focus_tea"; end
+    end
+
+    -- Chi Burst
+    if S.ChiBurst:IsReady() and not Player:IsMoving() then
+      if Cast(S.ChiBurst, nil, nil, not Target:IsInRange(40)) then return "chi_burst"; end
+    end
+
+    -- Chi Wave 
+    if S.ChiWave:IsReady() then
+      if Cast(S.ChiWave, nil, nil, not Target:IsInRange(40)) then return "chi_wave"; end
+    end
+
+    -- Celestial Conduit for AoE
+    if S.CelestialConduit:IsReady() and EnemiesCount5 > 1 then
+      if Cast(S.CelestialConduit, nil, nil, not Target:IsInRange(40)) then return "celestial_conduit"; end
+    end
+
+    -- Expel Harm with buffs
+    if S.ExpelHarm:IsReady() and (not Settings.Mistweaver.RequireExpelHarmBuffs or 
+      (Player:BuffUp(S.EnvelopingMistBuff) and Player:BuffUp(S.RenewingMistBuff) and Player:BuffUp(S.ChiHarmonyBuff))) then
+      if Cast(S.ExpelHarm, nil, nil, not Target:IsInRange(20)) then return "expel_harm"; end
+    end
+
+    -- Jadefire Stomp
+    if S.JadefireStomp:IsReady() then
+      if Cast(S.JadefireStomp, nil, nil, not Target:IsInRange(30)) then return "jadefire_stomp"; end
+    end
+
+    -- Spinning Crane Kick for AoE
+    if S.SpinningCraneKick:IsReady() and EnemiesCount5 >= Settings.Mistweaver.SpinningCraneKickThreshold then
+      if Cast(S.SpinningCraneKick, nil, nil, not Target:IsInMeleeRange(8)) then return "spinning_crane_kick"; end
+    end
+
+    -- Rising Sun Kick
+    if S.RisingSunKick:IsReady() then
+      if Cast(S.RisingSunKick, nil, nil, not Target:IsInMeleeRange(5)) then return "rising_sun_kick"; end
+    end
+
+    -- Alternate Blackout Kick/Tiger Palm for RSK reset chance
+    if Player:PrevGCD(1, S.BlackoutKick) then
+      if S.TigerPalm:IsReady() then
+        if Cast(S.TigerPalm, nil, nil, not Target:IsInMeleeRange(5)) then return "tiger_palm alternating"; end
+      end
+    else
+      if S.BlackoutKick:IsReady() then
+        if Cast(S.BlackoutKick, nil, nil, not Target:IsInMeleeRange(5)) then return "blackout_kick alternating"; end
+      end
+    end
+  end
+end
+
+local function Init()
+  HR.Print("Mistweaver Monk rotation has been initialized")
+end
+
+HR.SetAPL(270, APL, Init) 

--- a/HeroRotation_Monk/Mistweaver.lua
+++ b/HeroRotation_Monk/Mistweaver.lua
@@ -116,9 +116,14 @@ end
 
 local function PureDPSPriority()  -- Used when CDs ON - Maximum damage
   -- Crackling Jade Lightning with Jade Empowerment - Only in AoE 4+ targets
+  -- Wait for 3 stacks in AoE for maximum chain damage
   if S.CracklingJadeLightning:IsReady() and Player:BuffUp(S.JadeEmpowermentBuff) and EnemiesCount5 >= 4 then
-    if Cast(S.CracklingJadeLightning, nil, nil, not Target:IsSpellInRange(S.CracklingJadeLightning)) then 
-      return "crackling_jade_lightning empowered aoe"; 
+    local jeStacks = Player:BuffStack(S.JadeEmpowermentBuff)
+    -- Use at 3 stacks for maximum damage, or at any stack if buff is about to expire
+    if jeStacks == 3 or Player:BuffRemains(S.JadeEmpowermentBuff) < 2 then
+      if Cast(S.CracklingJadeLightning, nil, nil, not Target:IsSpellInRange(S.CracklingJadeLightning)) then 
+        return "crackling_jade_lightning empowered aoe " .. jeStacks .. " stacks"; 
+      end
     end
   end
 

--- a/HeroRotation_Monk/Mistweaver.lua
+++ b/HeroRotation_Monk/Mistweaver.lua
@@ -208,6 +208,33 @@ local function PureDPSPriority()  -- Used when CDs ON - Maximum damage
 end
 
 local function FistweavingPriority()  -- Used when CDs OFF - Optimized for DPS healing
+  -- When Chi-ji is active, optimize kick usage for stacks
+  if Player:BuffUp(S.InvokeChiJiBuff) then
+    -- Rising Sun Kick priority remains high
+    if S.RisingSunKick:IsReady() then
+      if Cast(S.RisingSunKick, nil, nil, not Target:IsInMeleeRange(5)) then return "rising_sun_kick chiji"; end
+    end
+
+    -- Blackout Kick usage during Chi-ji
+    -- Only stack to 2 for optimal bird stack generation
+    if S.BlackoutKick:IsReady() then
+      local tomStacks = Player:BuffStack(S.TeachingsoftheMonasteryBuff)
+      if tomStacks <= 2 then
+        if Cast(S.BlackoutKick, nil, nil, not Target:IsInMeleeRange(5)) then return "blackout_kick chiji"; end
+      end
+    end
+
+    -- Tiger Palm during Chi-ji - only build to 2 stacks
+    if S.TigerPalm:IsReady() and Player:BuffStack(S.TeachingsoftheMonasteryBuff) < 2 then
+      if Cast(S.TigerPalm, nil, nil, not Target:IsInMeleeRange(5)) then return "tiger_palm chiji"; end
+    end
+
+    -- Spinning Crane Kick during Chi-ji for additional stacks
+    if S.SpinningCraneKick:IsReady() and EnemiesCount5 >= 3 then
+      if Cast(S.SpinningCraneKick) then return "spinning_crane_kick chiji"; end
+    end
+  end
+
   -- Touch of Death - Highest priority
   -- Important for both burst damage and healing through Ancient Teachings
   if S.TouchofDeath:IsReady() then

--- a/HeroRotation_Monk/Mistweaver.lua
+++ b/HeroRotation_Monk/Mistweaver.lua
@@ -122,15 +122,6 @@ local function PureDPSPriority()  -- Used when CDs ON - Maximum damage
     end
   end
 
-  -- Debug print at start of function
-  if Player:BuffUp(S.JadeEmpowerment) then
-    HR.Print("Jade Empowerment is UP!")
-    -- Add more debug info
-    HR.Print("CJL Ready: " .. tostring(S.CracklingJadeLightning:IsReady()))
-    HR.Print("Can Channel: " .. tostring(CanChannelCJL()))
-    HR.Print("Enemy Count: " .. tostring(EnemiesCount5))
-  end
-
   -- Thunder Focus Tea optimization
   -- Use with RSK if conditions align, otherwise save for Renewing Mist
   if S.ThunderFocusTea:IsReady() then

--- a/HeroRotation_Monk/Mistweaver.lua
+++ b/HeroRotation_Monk/Mistweaver.lua
@@ -48,6 +48,7 @@ S.JadeEmpowerment          = Spell(467317)
 S.AncientTeachings         = Spell(388023)
 S.CracklingJadeLightning   = Spell(117952)
 S.JadeEmpowermentBuff      = Spell(467317)
+S.RushingJadeWind          = Spell(116847)
 
 -- Items
 local I = Item.Monk.Mistweaver
@@ -141,9 +142,6 @@ local function PureDPSPriority()  -- Used when CDs ON - Maximum damage
   if S.InvokeChiJi:IsReady() and S.InvokersDelight:IsAvailable() then
     if Cast(S.InvokeChiJi) then return "invoke_chiji pure_dps"; end
   end
-  if S.InvokeYulon:IsReady() and S.InvokersDelight:IsAvailable() then
-    if Cast(S.InvokeYulon) then return "invoke_yulon pure_dps"; end
-  end
 
   -- Celestial Conduit
   if S.CelestialConduit:IsReady() then
@@ -202,6 +200,11 @@ local function PureDPSPriority()  -- Used when CDs ON - Maximum damage
   -- Spinning Crane Kick in AoE
   if S.SpinningCraneKick:IsReady() and (EnemiesCount5 >= 4 or Player:BuffUp(S.DanceofChijiBuff)) then
     if Cast(S.SpinningCraneKick) then return "spinning_crane_kick aoe pure_dps"; end
+  end
+
+  -- Rushing Jade Wind
+  if S.RushingJadeWind:IsReady() then
+    if Cast(S.RushingJadeWind) then return "rushing_jade_wind pure_dps"; end
   end
 
   return false
@@ -288,6 +291,11 @@ local function FistweavingPriority()  -- Used when CDs OFF - Optimized for DPS h
   -- Chi Burst for AoE healing/damage
   if S.ChiBurst:IsReady() and not Player:IsMoving() and EnemiesCount5 >= 2 then
     if Cast(S.ChiBurst, nil, nil, not Target:IsInRange(40)) then return "chi_burst aoe"; end
+  end
+
+  -- Rushing Jade Wind
+  if S.RushingJadeWind:IsReady() then
+    if Cast(S.RushingJadeWind) then return "rushing_jade_wind fistweave"; end
   end
 
   -- Spinning Crane Kick only in heavy AoE situations

--- a/HeroRotation_Monk/Monk.lua
+++ b/HeroRotation_Monk/Monk.lua
@@ -265,6 +265,14 @@ Spell.Monk.Mistweaver = MergeTableByKey(Spell.Monk.Commons, {
   CelestialConduit                    = Spell(443028),   -- Celestial Conduit ability
   HeartoftheJadeSerpentBuff           = Spell(456368),   -- Heart of the Jade Serpent buff
   HeartoftheJadeSerpentCDRBuff        = Spell(443421),   -- CDR buff from Heart of the Jade Serpent
+  
+  -- AoE Abilities
+  RushingJadeWind                      = Spell(116847),   -- AoE damage ability
+  RushingJadeWindBuff                  = Spell(116847),   -- Track the buff/uptime
+  
+  -- Celestials
+  InvokeYulon                          = Spell(322118),   -- Healing cooldown, no DPS benefit
+  InvokeChiJi                          = Spell(325197),   -- The Red Crane cooldown
 })
 
 -- Items

--- a/HeroRotation_Monk/Monk.lua
+++ b/HeroRotation_Monk/Monk.lua
@@ -282,8 +282,16 @@ Item.Monk.Brewmaster = MergeTableByKey(Item.Monk.Commons, {
 
 -- Register spell effects
 HL:RegisterForEvent(function()
-  -- ... existing registrations ...
-  
-  -- Register Mistweaver channeled spells
+  -- Register Mistweaver channeled spells and effects
   Spell.Monk.Mistweaver.CracklingJadeLightning:RegisterInFlight()
+  Spell.Monk.Mistweaver.CracklingJadeLightning:RegisterInFlightEffect(117952)
+  
+  -- Register important buff tracking
+  Spell.Monk.Mistweaver.JadeEmpowermentBuff:RegisterAuraTracking()
+  Spell.Monk.Mistweaver.TeachingsoftheMonasteryBuff:RegisterAuraTracking()
+  
+  -- Register other important spells
+  Spell.Monk.Mistweaver.ThunderFocusTea:RegisterInFlight()
+  
+  HR.Print("Monk Spell Registration Complete")
 end, "PLAYER_LOGIN")

--- a/HeroRotation_Monk/Monk.lua
+++ b/HeroRotation_Monk/Monk.lua
@@ -255,6 +255,11 @@ Spell.Monk.Mistweaver = MergeTableByKey(Spell.Monk.Commons, {
   -- Important Buffs to Track
   TeachingsoftheMonasteryBuff          = Spell(202090),   -- Track for RSK resets
   JadeEmpowermentBuff                  = Spell(467317),   -- From TFT, empowers CJL
+  
+  -- Chi-ji Related
+  InvokeChiJi                          = Spell(325197),   -- The Red Crane cooldown
+  InvokeChiJiBuff                      = Spell(343820),   -- Active buff when Chi-ji is summoned
+  EnvelopingBreathBuff                 = Spell(343819),   -- Stacks from kicks during Chi-ji
 })
 
 -- Items

--- a/HeroRotation_Monk/Monk.lua
+++ b/HeroRotation_Monk/Monk.lua
@@ -231,6 +231,7 @@ Spell.Monk.Mistweaver = MergeTableByKey(Spell.Monk.Commons, {
   ChiBurst                             = Spell(123986),
   ChiWave                              = Spell(115098),
   ThunderFocusTea                      = Spell(116680),
+  CracklingJadeLightning               = Spell(117952),
   
   -- Talents
   ChiHarmony                           = Spell(391315),
@@ -243,6 +244,7 @@ Spell.Monk.Mistweaver = MergeTableByKey(Spell.Monk.Commons, {
   CelestialConduit                     = Spell(392989),
   
   -- Buffs
+  TeachingsoftheMonasteryBuff          = Spell(202090),
   AncientConcordanceBuff               = Spell(389391),
   AwakenedJadefireBuff                 = Spell(388779),
   EnvelopingMistBuff                   = Spell(124682),

--- a/HeroRotation_Monk/Monk.lua
+++ b/HeroRotation_Monk/Monk.lua
@@ -260,6 +260,11 @@ Spell.Monk.Mistweaver = MergeTableByKey(Spell.Monk.Commons, {
   InvokeChiJi                          = Spell(325197),   -- The Red Crane cooldown
   InvokeChiJiBuff                      = Spell(343820),   -- Active buff when Chi-ji is summoned
   EnvelopingBreathBuff                 = Spell(343819),   -- Stacks from kicks during Chi-ji
+  
+  -- Celestial Conduit related
+  CelestialConduit                    = Spell(443028),   -- Celestial Conduit ability
+  HeartoftheJadeSerpentBuff           = Spell(456368),   -- Heart of the Jade Serpent buff
+  HeartoftheJadeSerpentCDRBuff        = Spell(443421),   -- CDR buff from Heart of the Jade Serpent
 })
 
 -- Items

--- a/HeroRotation_Monk/Monk.lua
+++ b/HeroRotation_Monk/Monk.lua
@@ -220,6 +220,36 @@ Spell.Monk.Brewmaster = MergeTableByKey(Spell.Monk.Commons, {
 Spell.Monk.Brewmaster = MergeTableByKey(Spell.Monk.Brewmaster, Spell.Monk.MasterofHarmony)
 Spell.Monk.Brewmaster = MergeTableByKey(Spell.Monk.Brewmaster, Spell.Monk.ShadoPan)
 
+Spell.Monk.Mistweaver = MergeTableByKey(Spell.Monk.Commons, {
+  -- Abilities
+  BlackoutKick                          = Spell(100784),
+  RisingSunKick                         = Spell(107428), 
+  SpinningCraneKick                     = Spell(101546),
+  TigerPalm                            = Spell(100780),
+  TouchofDeath                         = Spell(322109),
+  ExpelHarm                            = Spell(322101),
+  ChiBurst                             = Spell(123986),
+  ChiWave                              = Spell(115098),
+  ThunderFocusTea                      = Spell(116680),
+  
+  -- Talents
+  ChiHarmony                           = Spell(391315),
+  CraneStyle                           = Spell(391315), 
+  JadefireStomp                        = Spell(388193),
+  AncientConcordance                   = Spell(389391),
+  AncientTeachings                     = Spell(388023),
+  AwakenedJadefire                     = Spell(388779),
+  FatalTouch                           = Spell(394123),
+  CelestialConduit                     = Spell(392989),
+  
+  -- Buffs
+  AncientConcordanceBuff               = Spell(389391),
+  AwakenedJadefireBuff                 = Spell(388779),
+  EnvelopingMistBuff                   = Spell(124682),
+  RenewingMistBuff                     = Spell(119611),
+  ChiHarmonyBuff                       = Spell(391315),
+})
+
 -- Items
 if not Item.Monk then Item.Monk = {}; end
 Item.Monk.Commons = {

--- a/HeroRotation_Monk/Monk.lua
+++ b/HeroRotation_Monk/Monk.lua
@@ -1,4 +1,8 @@
 --- ============================ HEADER ============================
+--- Monk Class Spell Definitions
+--- Includes all specs with special focus on Mistweaver's unique mechanics
+--- Particularly important for fistweaving and DPS healing capabilities
+
 --- ======= LOCALIZE =======
 -- Addon
 local addonName, addonTable = ...
@@ -223,36 +227,34 @@ Spell.Monk.Brewmaster = MergeTableByKey(Spell.Monk.Brewmaster, Spell.Monk.Master
 Spell.Monk.Brewmaster = MergeTableByKey(Spell.Monk.Brewmaster, Spell.Monk.ShadoPan)
 
 Spell.Monk.Mistweaver = MergeTableByKey(Spell.Monk.Commons, {
-  -- Abilities
-  BlackoutKick                          = Spell(100784),
-  RisingSunKick                         = Spell(107428), 
-  SpinningCraneKick                     = Spell(101546),
-  TigerPalm                            = Spell(100780),
-  TouchofDeath                         = Spell(322109),
-  ExpelHarm                            = Spell(322101),
-  ChiBurst                             = Spell(123986),
-  ChiWave                              = Spell(115098),
-  ThunderFocusTea                      = Spell(116680),
-  CracklingJadeLightning               = Spell(117952),
+  -- Core Abilities
+  -- These form the backbone of both healing and DPS rotations
+  BlackoutKick                          = Spell(100784),  -- Core ability for RSK resets
+  RisingSunKick                         = Spell(107428),  -- Primary damage and healing ability
+  SpinningCraneKick                     = Spell(101546),  -- AoE damage option
+  TigerPalm                            = Spell(100780),   -- Basic builder for ToM stacks
+  TouchofDeath                         = Spell(322109),   -- Burst damage/healing cooldown
   
-  -- Talents
-  ChiHarmony                           = Spell(391315),
-  CraneStyle                           = Spell(391315), 
-  JadefireStomp                        = Spell(388193),
-  AncientConcordance                   = Spell(389391),
-  AncientTeachings                     = Spell(388023),
-  AwakenedJadefire                     = Spell(388779),
-  FatalTouch                           = Spell(394123),
-  CelestialConduit                     = Spell(392989),
+  -- Key Healing Abilities that interact with DPS
+  ExpelHarm                            = Spell(322101),   -- Emergency heal that converts to damage
+  ChiBurst                             = Spell(123986),   -- AoE healing and damage
+  ChiWave                              = Spell(115098),   -- Single target healing/damage
   
-  -- Buffs
-  TeachingsoftheMonasteryBuff          = Spell(202090),
-  AncientConcordanceBuff               = Spell(389391),
-  AwakenedJadefireBuff                 = Spell(388779),
-  EnvelopingMistBuff                   = Spell(124682),
-  RenewingMistBuff                     = Spell(119611),
-  ChiHarmonyBuff                       = Spell(391315),
-  JadeEmpowermentBuff      = Spell(467317),
+  -- Important Cooldowns
+  ThunderFocusTea                      = Spell(116680),   -- Core cooldown for empowerment
+  CracklingJadeLightning               = Spell(117952),   -- Ranged channel, important with Jade Empowerment
+  
+  -- Modern Talents (11.0.5+)
+  ChiHarmony                           = Spell(391315),   -- Healing increase from damage
+  CraneStyle                           = Spell(391315),   -- Core fistweaving talent
+  JadefireStomp                        = Spell(388193),   -- Important buff maintenance
+  AncientConcordance                   = Spell(389391),   -- Buff from Jadefire
+  AncientTeachings                     = Spell(388023),   -- Core healing through damage
+  AwakenedJadefire                     = Spell(388779),   -- Additional Jadefire buff
+  
+  -- Important Buffs to Track
+  TeachingsoftheMonasteryBuff          = Spell(202090),   -- Track for RSK resets
+  JadeEmpowermentBuff                  = Spell(467317),   -- From TFT, empowers CJL
 })
 
 -- Items

--- a/HeroRotation_Monk/Monk.lua
+++ b/HeroRotation_Monk/Monk.lua
@@ -84,6 +84,8 @@ Spell.Monk.Commons = {
   DampenHarmBuff                        = Spell(122278),
   PressurePointBuff                     = Spell(393053),
   RushingJadeWindBuff                   = Spell(116847),
+  JadeEmpowerment          = Spell(467317),
+  JadeEmpowermentBuff      = Spell(467317),
   -- Debuffs
   -- Item Effects
   CalltoDominanceBuff                   = Spell(403380), -- Neltharion trinket buff
@@ -250,6 +252,7 @@ Spell.Monk.Mistweaver = MergeTableByKey(Spell.Monk.Commons, {
   EnvelopingMistBuff                   = Spell(124682),
   RenewingMistBuff                     = Spell(119611),
   ChiHarmonyBuff                       = Spell(391315),
+  JadeEmpowermentBuff      = Spell(467317),
 })
 
 -- Items
@@ -274,3 +277,11 @@ Item.Monk.Windwalker = MergeTableByKey(Item.Monk.Commons, {
 
 Item.Monk.Brewmaster = MergeTableByKey(Item.Monk.Commons, {
 })
+
+-- Register spell effects
+HL:RegisterForEvent(function()
+  -- ... existing registrations ...
+  
+  -- Register Mistweaver channeled spells
+  Spell.Monk.Mistweaver.CracklingJadeLightning:RegisterInFlight()
+end, "PLAYER_LOGIN")

--- a/HeroRotation_Monk/Overrides.lua
+++ b/HeroRotation_Monk/Overrides.lua
@@ -83,6 +83,9 @@ HL.AddCoreOverride("Player.IsChanneling",
 local MWOldBuffUp
 MWOldBuffUp = HL.AddCoreOverride("Player.BuffUp",
   function(self, Spell, AnyCaster, Offset)
+    -- Add nil check for Spell
+    if not Spell then return false end
+    
     -- Special handling for Jade Empowerment buff detection
     if Spell == SpellMW.JadeEmpowermentBuff then
       local name = AuraUtil.FindAuraByName(Spell:Name(), "player", "HELPFUL")
@@ -97,6 +100,9 @@ MWOldBuffUp = HL.AddCoreOverride("Player.BuffUp",
 local MWOldBuffStack
 MWOldBuffStack = HL.AddCoreOverride("Player.BuffStack",
   function(self, Spell, AnyCaster, Offset)
+    -- Add nil check for Spell
+    if not Spell then return 0 end
+    
     if Spell == SpellMW.JadeEmpowermentBuff then
       local name, _, count = AuraUtil.FindAuraByName(Spell:Name(), "player", "HELPFUL")
       return count or 0
@@ -110,6 +116,9 @@ MWOldBuffStack = HL.AddCoreOverride("Player.BuffStack",
 local MWOldBuffRemains
 MWOldBuffRemains = HL.AddCoreOverride("Player.BuffRemains", 
   function(self, Spell, AnyCaster, Offset)
+    -- Add nil check for Spell
+    if not Spell then return 0 end
+    
     if Spell == SpellMW.JadeEmpowermentBuff then
       local name, _, _, _, duration, expirationTime = AuraUtil.FindAuraByName(Spell:Name(), "player", "HELPFUL")
       if name then

--- a/HeroRotation_Monk/Overrides.lua
+++ b/HeroRotation_Monk/Overrides.lua
@@ -13,6 +13,7 @@
 -- Spells
   local SpellBM = Spell.Monk.Brewmaster
   local SpellWW = Spell.Monk.Windwalker
+  local SpellMW = Spell.Monk.Mistweaver
 -- Lua
 
 --- ============================ CONTENT ============================
@@ -43,3 +44,71 @@ WWOldSpellIsCastable = HL.AddCoreOverride ("Spell.IsCastable",
     end
   end
 , 269)
+
+-- Mistweaver, ID: 270
+local MWOldSpellIsCastable
+MWOldSpellIsCastable = HL.AddCoreOverride ("Spell.IsCastable",
+  function (self, BypassRecovery, Range, AoESpell, ThisUnit, Offset)
+    local BaseCheck = MWOldSpellIsCastable and MWOldSpellIsCastable(self, BypassRecovery, Range, AoESpell, ThisUnit, Offset) or 
+      (self:IsLearned() and self:CooldownRemains( BypassRecovery, Offset or "Auto") == 0)
+    if self == SpellMW.CracklingJadeLightning then
+      return BaseCheck and not Player:IsChanneling() and Player:Energy() >= 20
+    else
+      return BaseCheck
+    end
+  end
+, 270)
+
+-- Add channeling override
+HL.AddCoreOverride("Player.IsChanneling",
+  function(self, ...)
+    if self:IsCasting() then
+      local CastingInfo = self:CastingInfo()
+      if CastingInfo == SpellMW.CracklingJadeLightning:Name() then
+        return true
+      end
+    end
+    return false
+  end
+, 270)
+
+-- Add buff override for Mistweaver
+local MWOldBuffUp
+MWOldBuffUp = HL.AddCoreOverride("Player.BuffUp",
+  function(self, Spell, AnyCaster, Offset)
+    if Spell == SpellMW.JadeEmpowermentBuff then
+      local name = AuraUtil.FindAuraByName(Spell:Name(), "player", "HELPFUL")
+      return name ~= nil
+    end
+    -- Use standard check for other buffs
+    return MWOldBuffUp and MWOldBuffUp(self, Spell, AnyCaster, Offset) or false
+  end
+, 270)
+
+-- Add buff stack override
+local MWOldBuffStack
+MWOldBuffStack = HL.AddCoreOverride("Player.BuffStack",
+  function(self, Spell, AnyCaster, Offset)
+    if Spell == SpellMW.JadeEmpowermentBuff then
+      local name, _, count = AuraUtil.FindAuraByName(Spell:Name(), "player", "HELPFUL")
+      return count or 0
+    end
+    -- Use standard check for other buffs
+    return MWOldBuffStack and MWOldBuffStack(self, Spell, AnyCaster, Offset) or 0
+  end
+, 270)
+
+-- Add buff remains override
+local MWOldBuffRemains
+MWOldBuffRemains = HL.AddCoreOverride("Player.BuffRemains", 
+  function(self, Spell, AnyCaster, Offset)
+    if Spell == SpellMW.JadeEmpowermentBuff then
+      local name, _, _, _, duration, expirationTime = AuraUtil.FindAuraByName(Spell:Name(), "player", "HELPFUL")
+      if name then
+        return expirationTime - GetTime()
+      end
+      return 0
+    end
+    return MWOldBuffRemains and MWOldBuffRemains(self, Spell, AnyCaster, Offset) or 0
+  end
+, 270)

--- a/HeroRotation_Monk/Settings.lua
+++ b/HeroRotation_Monk/Settings.lua
@@ -43,6 +43,7 @@ HR.GUISettings.APL.Monk = {
     -- {Display OffGCD as OffGCD, ForceReturn}
     OffGCDasOffGCD = {
       Racials = true,
+      SpearHandStrike = true,
     }
   },
   Brewmaster = {
@@ -103,6 +104,30 @@ HR.GUISettings.APL.Monk = {
       StormEarthAndFire = true,
     }
   },
+  Mistweaver = {
+    -- Add potion type settings
+    PotionType = {
+      Selected = "Tempered",
+    },
+    -- Thresholds and Toggles
+    SpinningCraneKickThreshold = 4,  -- Default to 4 targets
+    RequireExpelHarmBuffs = true,    -- Whether to require buffs for Expel Harm
+    ThunderFocusTeaWithExpelHarm = true, -- Use TFT with Expel Harm
+    -- {Display GCD as OffGCD, ForceReturn}
+    GCDasOffGCD = {
+      -- Abilities
+      TouchofDeath = true,
+      ExpelHarm = false,
+      ChiBurst = false,
+      ChiWave = false,
+    },
+    -- {Display OffGCD as OffGCD, ForceReturn}
+    OffGCDasOffGCD = {
+      -- Racials
+      -- Abilities
+      ThunderFocusTea = true,
+    }
+  },
 }
 
 HR.GUI.LoadSettingsRecursively(HR.GUISettings)
@@ -114,6 +139,7 @@ local CP_MonkDS = CreateChildPanel(CP_Monk, "Class DisplayStyles")
 local CP_MonkOGCD = CreateChildPanel(CP_Monk, "Class OffGCDs")
 local CP_Windwalker = CreateChildPanel(CP_Monk, "Windwalker")
 local CP_Brewmaster = CreateChildPanel(CP_Monk, "Brewmaster")
+local CP_Mistweaver = CreateChildPanel(CP_Monk, "Mistweaver")
 
 -- Monk
 CreateARPanelOptions(CP_Monk, "APL.Monk.Commons")
@@ -132,3 +158,12 @@ CreatePanelOption("Slider", CP_Windwalker, "APL.Monk.Windwalker.MotCMinTimeThres
 -- Brewmaster
 CreatePanelOption("Slider", CP_Brewmaster, "APL.Monk.Brewmaster.ExpelHarmHP", {1, 100, 1}, "Expel Harm HP Threshold", "Set the HP threshold for when to suggest Expel Harm.")
 CreateARPanelOptions(CP_Brewmaster, "APL.Monk.Brewmaster")
+
+-- Mistweaver
+CreateARPanelOptions(CP_Mistweaver, "APL.Monk.Mistweaver")
+CreatePanelOption("Slider", CP_Mistweaver, "APL.Monk.Mistweaver.SpinningCraneKickThreshold", {2, 8, 1}, 
+  "Spinning Crane Kick Threshold", "Set the minimum number of targets to use Spinning Crane Kick. Default: 4")
+CreatePanelOption("CheckButton", CP_Mistweaver, "APL.Monk.Mistweaver.RequireExpelHarmBuffs", 
+  "Require Expel Harm Buffs", "If enabled, only suggest Expel Harm when Enveloping Mist, Renewing Mist and Chi Harmony buffs are active.")
+CreatePanelOption("CheckButton", CP_Mistweaver, "APL.Monk.Mistweaver.ThunderFocusTeaWithExpelHarm",
+  "Thunder Focus Tea with Expel Harm", "If enabled, try to sync Thunder Focus Tea with Expel Harm for increased damage.")

--- a/HeroRotation_Monk/Settings.lua
+++ b/HeroRotation_Monk/Settings.lua
@@ -109,8 +109,7 @@ HR.GUISettings.APL.Monk = {
     PotionType = {
       Selected = "Tempered",
     },
-    -- Thresholds and Toggles
-    SpinningCraneKickThreshold = 4,  -- Default to 4 targets
+    -- Remove SpinningCraneKickThreshold
     RequireExpelHarmBuffs = true,    -- Whether to require buffs for Expel Harm
     ThunderFocusTeaWithExpelHarm = true, -- Use TFT with Expel Harm
     -- {Display GCD as OffGCD, ForceReturn}
@@ -161,8 +160,6 @@ CreateARPanelOptions(CP_Brewmaster, "APL.Monk.Brewmaster")
 
 -- Mistweaver
 CreateARPanelOptions(CP_Mistweaver, "APL.Monk.Mistweaver")
-CreatePanelOption("Slider", CP_Mistweaver, "APL.Monk.Mistweaver.SpinningCraneKickThreshold", {2, 8, 1}, 
-  "Spinning Crane Kick Threshold", "Set the minimum number of targets to use Spinning Crane Kick. Default: 4")
 CreatePanelOption("CheckButton", CP_Mistweaver, "APL.Monk.Mistweaver.RequireExpelHarmBuffs", 
   "Require Expel Harm Buffs", "If enabled, only suggest Expel Harm when Enveloping Mist, Renewing Mist and Chi Harmony buffs are active.")
 CreatePanelOption("CheckButton", CP_Mistweaver, "APL.Monk.Mistweaver.ThunderFocusTeaWithExpelHarm",

--- a/HeroRotation_Monk/Settings.lua
+++ b/HeroRotation_Monk/Settings.lua
@@ -100,6 +100,7 @@ HR.GUISettings.APL.Monk = {
       Revival = "Cooldown",
       LifeCocoon = "Cooldown",
       CelestialConduit = "Cooldown",
+      CracklingJadeLightning = "Cooldown",
     },
   },
 }

--- a/HeroRotation_Monk/Settings.lua
+++ b/HeroRotation_Monk/Settings.lua
@@ -13,64 +13,48 @@ local CreatePanelOption = GUI.CreatePanelOption
 local CreateARPanelOption = HR.GUI.CreateARPanelOption
 local CreateARPanelOptions = HR.GUI.CreateARPanelOptions
 
---- ============================ CONTENT ============================
--- All settings here should be moved into the GUI someday.
+--- ============================ CONTENT ===========================
 HR.GUISettings.APL.Monk = {
   Commons = {
     Enabled = {
       Trinkets = true,
-      Potions = true,
       Items = true,
     },
   },
   CommonsDS = {
     DisplayStyle = {
-      -- Common
       Interrupts = "Cooldown",
       Items = "Suggested",
-      Potions = "Suggested",
       Trinkets = "Suggested",
-      -- Class Specific
     },
   },
   CommonsOGCD = {
-    -- {Display GCD as OffGCD, ForceReturn}
     GCDasOffGCD = {
-      Paralysis = true,
-      RingOfPeace = true,
-      SummonWhiteTigerStatue = true,
+      Paralysis = false,
+      RingOfPeace = false,
+      SummonWhiteTigerStatue = false,
     },
-    -- {Display OffGCD as OffGCD, ForceReturn}
     OffGCDasOffGCD = {
-      Racials = true,
+      Racials = false,
       SpearHandStrike = true,
     }
   },
   Brewmaster = {
     ExpelHarmHP = 70,
-    PotionType = {
-      Selected = "Tempered",
-    },
-    -- DisplayStyle for Brewmaster-only stuff
     DisplayStyle = {
       CelestialBrew = "Suggested",
       DampenHarm = "Suggested",
       FortifyingBrew = "Suggested",
       Purify = "SuggestedRight"
     },
-    -- {Display GCD as OffGCD, ForceReturn}
     GCDasOffGCD = {
-      -- Abilities
       BreathOfFire = false,
       ExpelHarm = false,
       ExplodingKeg = false,
       InvokeNiuzaoTheBlackOx = true,
       TouchOfDeath = true,
     },
-    -- {Display OffGCD as OffGCD, ForceReturn}
     OffGCDasOffGCD = {
-      -- Racials
-      -- Abilities
       BlackOxBrew = true,
       PurifyingBrew = true,
     }
@@ -82,12 +66,7 @@ HR.GUISettings.APL.Monk = {
     ShowFortifyingBrewCD = false,
     MotCCountThreshold = 5,
     MotCMinTimeThreshold = 5,
-    PotionType = {
-      Selected = "Tempered",
-    },
-    -- {Display GCD as OffGCD, ForceReturn}
     GCDasOffGCD = {
-      -- Abilities
       CracklingJadeLightning = false,
       FortifyingBrew = true,
       InvokeXuenTheWhiteTiger = true,
@@ -95,72 +74,58 @@ HR.GUISettings.APL.Monk = {
       TouchOfDeath = true,
       TouchOfKarma = true,
     },
-    -- {Display OffGCD as OffGCD, ForceReturn}
     OffGCDasOffGCD = {
-      -- Racials
-      -- Abilities
       EnergizingElixir = true,
       Serenity = true,
       StormEarthAndFire = true,
     }
   },
   Mistweaver = {
-    -- Add potion type settings
-    PotionType = {
-      Selected = "Tempered",
+    DisplayStyle = {
+      -- Main icon - DPS abilities
+      RisingSunKick = "Suggested",
+      BlackoutKick = "Suggested",
+      TigerPalm = "Suggested",
+      SpinningCraneKick = "Suggested",
+      
+      -- Left icon - Instant heals
+      ExpelHarm = "SuggestedRight",
+      RenewingMist = "SuggestedRight",
+      InstantEnvelopingMist = "SuggestedRight",
+      InstantVivify = "SuggestedRight",
+      
+      -- Cooldowns
+      ThunderFocusTea = "Cooldown",
+      InvokeChiJi = "Cooldown",
+      Revival = "Cooldown",
+      LifeCocoon = "Cooldown",
+      CelestialConduit = "Cooldown",
     },
-    -- Remove SpinningCraneKickThreshold
-    RequireExpelHarmBuffs = true,    -- Whether to require buffs for Expel Harm
-    ThunderFocusTeaWithExpelHarm = true, -- Use TFT with Expel Harm
-    -- {Display GCD as OffGCD, ForceReturn}
-    GCDasOffGCD = {
-      -- Abilities
-      TouchofDeath = true,
-      ExpelHarm = false,
-      ChiBurst = false,
-      ChiWave = false,
-    },
-    -- {Display OffGCD as OffGCD, ForceReturn}
-    OffGCDasOffGCD = {
-      -- Racials
-      -- Abilities
-      ThunderFocusTea = true,
-    }
   },
 }
 
 HR.GUI.LoadSettingsRecursively(HR.GUISettings)
 
--- Child Panels
+-- Create panels
 local ARPanel = HR.GUI.Panel
 local CP_Monk = CreateChildPanel(ARPanel, "Monk")
 local CP_MonkDS = CreateChildPanel(CP_Monk, "Class DisplayStyles")
-local CP_MonkOGCD = CreateChildPanel(CP_Monk, "Class OffGCDs")
 local CP_Windwalker = CreateChildPanel(CP_Monk, "Windwalker")
 local CP_Brewmaster = CreateChildPanel(CP_Monk, "Brewmaster")
-local CP_Mistweaver = CreateChildPanel(CP_Monk, "Mistweaver")
 
--- Monk
+-- Create panel options
 CreateARPanelOptions(CP_Monk, "APL.Monk.Commons")
 CreateARPanelOptions(CP_MonkDS, "APL.Monk.CommonsDS")
-CreateARPanelOptions(CP_MonkOGCD, "APL.Monk.CommonsOGCD")
-
--- Windwalker
 CreateARPanelOptions(CP_Windwalker, "APL.Monk.Windwalker")
-CreatePanelOption("CheckButton", CP_Windwalker, "APL.Monk.Windwalker.ShowFortifyingBrewCD", "Fortifying Brew", "Enable or disable Fortifying Brew recommendations.")
-CreatePanelOption("CheckButton", CP_Windwalker, "APL.Monk.Windwalker.IgnoreToK", "Ignore Touch of Karma", "Enable this setting to allow you to ignore Touch of Karma without stalling the rotation. (NOTE: Touch of Karma will never be suggested if this is enabled)")
-CreatePanelOption("CheckButton", CP_Windwalker, "APL.Monk.Windwalker.IgnoreFSK", "Ignore Flying Serpent Kick", "Enable this setting to allow you to ignore Flying Serpent Kick without stalling the rotation. (NOTE: Flying Serpent Kick will never be suggested if this is enabled)")
-CreatePanelOption("Slider", CP_Windwalker, "APL.Monk.Windwalker.FortifyingBrewHP", {1, 100, 1}, "Fortifying Brew HP Threshold", "Set the HP threshold for when to suggest Fortifying Brew.")
-CreatePanelOption("Slider", CP_Windwalker, "APL.Monk.Windwalker.MotCCountThreshold", {1, 10, 1}, "Mark of the Crane Count Threshold", "Allow the profile to cycle through targets to apply Mark of the Crane is below this number of targets with the debuff applied. Default: 5.")
-CreatePanelOption("Slider", CP_Windwalker, "APL.Monk.Windwalker.MotCMinTimeThreshold", {1, 20, 1}, "Mark of the Crane Min Time Threshold", "Allow the profile to cycle through targets to apply Mark of the Crane if the remaining time on any Mark of the Crane debuff is below this number of seconds. Default: 5.")
-
--- Brewmaster
-CreatePanelOption("Slider", CP_Brewmaster, "APL.Monk.Brewmaster.ExpelHarmHP", {1, 100, 1}, "Expel Harm HP Threshold", "Set the HP threshold for when to suggest Expel Harm.")
 CreateARPanelOptions(CP_Brewmaster, "APL.Monk.Brewmaster")
 
--- Mistweaver
-CreateARPanelOptions(CP_Mistweaver, "APL.Monk.Mistweaver")
-CreatePanelOption("CheckButton", CP_Mistweaver, "APL.Monk.Mistweaver.RequireExpelHarmBuffs", 
-  "Require Expel Harm Buffs", "If enabled, only suggest Expel Harm when Enveloping Mist, Renewing Mist and Chi Harmony buffs are active.")
-CreatePanelOption("CheckButton", CP_Mistweaver, "APL.Monk.Mistweaver.ThunderFocusTeaWithExpelHarm",
-  "Thunder Focus Tea with Expel Harm", "If enabled, try to sync Thunder Focus Tea with Expel Harm for increased damage.")
+-- Windwalker specific options
+CreatePanelOption("CheckButton", CP_Windwalker, "APL.Monk.Windwalker.ShowFortifyingBrewCD", "Fortifying Brew", "Enable or disable Fortifying Brew recommendations.")
+CreatePanelOption("CheckButton", CP_Windwalker, "APL.Monk.Windwalker.IgnoreToK", "Ignore Touch of Karma", "Enable this setting to allow you to ignore Touch of Karma without stalling the rotation.")
+CreatePanelOption("CheckButton", CP_Windwalker, "APL.Monk.Windwalker.IgnoreFSK", "Ignore Flying Serpent Kick", "Enable this setting to allow you to ignore Flying Serpent Kick without stalling the rotation.")
+CreatePanelOption("Slider", CP_Windwalker, "APL.Monk.Windwalker.FortifyingBrewHP", {1, 100, 1}, "Fortifying Brew HP Threshold", "Set the HP threshold for when to suggest Fortifying Brew.")
+CreatePanelOption("Slider", CP_Windwalker, "APL.Monk.Windwalker.MotCCountThreshold", {1, 10, 1}, "Mark of the Crane Count Threshold", "Allow the profile to cycle through targets to apply Mark of the Crane.")
+CreatePanelOption("Slider", CP_Windwalker, "APL.Monk.Windwalker.MotCMinTimeThreshold", {1, 20, 1}, "Mark of the Crane Min Time Threshold", "Allow the profile to cycle through targets to apply Mark of the Crane.")
+
+-- Brewmaster specific options
+CreatePanelOption("Slider", CP_Brewmaster, "APL.Monk.Brewmaster.ExpelHarmHP", {1, 100, 1}, "Expel Harm HP Threshold", "Set the HP threshold for when to suggest Expel Harm.")


### PR DESCRIPTION
Add initial support for Mistweaver Monk DPS rotation based on the Mistweaver DPS guide.

Changes:
- Added Mistweaver DPS spell list to Monk.lua
- Created new Mistweaver.lua with DPS-focused rotation
- Added Mistweaver settings panel with configurable options:
  - Spinning Crane Kick enemy threshold
  - Expel Harm buff requirements toggle
  - Thunder Focus Tea usage options
- Updated Main.lua to enable Mistweaver spec (270)
- Added potion and interrupt support
- Implemented basic DPS priority:
  1. Touch of Death
  2. Chi Burst/Chi Wave
  3. Celestial Conduit for AoE
  4. Expel Harm with buffs
  5. Jadefire Stomp
  6. Spinning Crane Kick (4+ targets)
  7. Rising Sun Kick
  8. Alternating Blackout Kick/Tiger Palm

This provides a foundation for Mistweaver monks to deal damage during healing downtime. The rotation focuses on key damage abilities while maintaining proper buff management.

Note: This is an initial implementation focused on damage dealing. Future improvements could include better cooldown management and situational ability usage.