### PR TITLE
Better Fury of the Sun King Cast Timing + Fire 11.1.0 APL Update.

### DIFF
--- a/HeroRotation_Mage/Fire.lua
+++ b/HeroRotation_Mage/Fire.lua
@@ -129,9 +129,9 @@ SetTrinketVariables()
 --- ===== Precombat Variables =====
 local function SetPrecombatVariables()
   VarFirestarterCombusion = S.SunKingsBlessing:IsAvailable()
-  VarHotStreakFlamestrike = 4 * num(S.Quickflame:IsAvailable() or S.FlamePatch:IsAvailable()) + 999 * num(not S.FlamePatch:IsAvailable() and not S.Quickflame:IsAvailable())
+  VarHotStreakFlamestrike = 5 * num(S.Quickflame:IsAvailable() or S.FlamePatch:IsAvailable()) + 6 * num(S.Firefall:IsAvailable()) + 999 * num(not S.FlamePatch:IsAvailable() and not S.Quickflame:IsAvailable() and not S.Firefall:IsAvailable())
   VarHardCastFlamestrike = 999
-  VarCombustionFlamestrike = 4 * num(S.Quickflame:IsAvailable() or S.FlamePatch:IsAvailable()) + 999 * num(not S.FlamePatch:IsAvailable() and not S.Quickflame:IsAvailable())
+  VarCombustionFlamestrike = 5 * num(S.Quickflame:IsAvailable() or S.FlamePatch:IsAvailable()) + 6 * num(S.Firefall:IsAvailable()) + 999 * num(not S.FlamePatch:IsAvailable() and not S.Quickflame:IsAvailable() and not S.Firefall:IsAvailable())
   VarSKBFlamestrike = 3 * num(S.Quickflame:IsAvailable() or S.FlamePatch:IsAvailable()) + 999 * num(not S.FlamePatch:IsAvailable() and not S.Quickflame:IsAvailable())
   VarArcaneExplosion = 999
   VarArcaneExplosionMana = 40
@@ -290,6 +290,10 @@ local function ActiveTalents()
       if Cast(S.DragonsBreath, Settings.Fire.GCDasOffGCD.DragonsBreath) then return "dragons_breath active_talents 4"; end
     end
   end
+  -- meteor,if=talent.unleashed_inferno&buff.excess_fire.stack<2
+  if S.Meteor:IsReady() and (S.UnleashedInferno:IsAvailable() and Player:BuffStack(S.ExcessFireBuff) < 2) then
+    if Cast(S.Meteor, Settings.Fire.GCDasOffGCD.Meteor, nil, not Target:IsInRange(40)) then return "meteor active_talents 6"; end
+  end
 end
 
 local function CombustionCooldowns()
@@ -374,7 +378,7 @@ local function CombustionPhase()
     if Cast(S.Pyroblast, nil, nil, not Target:IsSpellInRange(S.Pyroblast)) then return "pyroblast combustion_phase 10"; end
   end
   -- meteor,if=talent.isothermic_core&buff.combustion.down&cooldown.combustion.remains<cast_time
-  if S.Meteor:IsReady() and (S.IsothermicCore:IsAvailable() and CombustionDown and S.Combustion:CooldownRemains() < S.Meteor:CastTime()) then
+  if S.Meteor:IsReady() and (not S.UnleashedInferno:IsAvailable() and S.IsothermicCore:IsAvailable() and CombustionDown and S.Combustion:CooldownRemains() < S.Meteor:CastTime()) then
     if Cast(S.Meteor, Settings.Fire.GCDasOffGCD.Meteor, nil, not Target:IsInRange(40)) then return "meteor combustion_phase 12"; end
   end
   -- fireball,if=buff.combustion.down&cooldown.combustion.remains<cast_time&active_enemies<2&!improved_scorch.active&!(talent.sun_kings_blessing&talent.flame_accelerant)
@@ -548,6 +552,10 @@ local function StandardRotation()
   if S.FireBlast:IsReady() and not FreeCastAvailable() and (not FirestarterActive() and ((not VarFireBlastPooling and S.UnleashedInferno:IsAvailable()) or S.SpontaneousCombustion:IsAvailable()) and Player:BuffDown(S.FuryoftheSunKingBuff) and (HeatingUp and HotStreakInFlight() < 1 and (Player:PrevGCDP(1, S.PhoenixFlames) or Player:PrevGCDP(1, S.Scorch))) or (((Player:BloodlustUp() and S.FireBlast:ChargesFractional() > 1.5) or S.FireBlast:ChargesFractional() > 2.5 or Player:BuffRemains(S.FeeltheBurnBuff) < 0.5 or S.FireBlast:FullRechargeTime() * 1 - (0.5 * num(S.ShiftingPower:CooldownUp())) < 6) and HeatingUp)) then
     if CastLeft(S.FireBlast) then return "fire_blast standard_rotation 10"; end
   end
+  -- fire_blast,use_off_gcd=1,use_while_casting=1,if=buff.hyperthermia.up&charges_fractional>1.5&buff.heating_up.react
+  if S.FireBlast:IsReady() and not FreeCastAvailable() and (Player:BuffUp(S.HyperthermiaBuff) and S.FireBlast:ChargesFractional() > 1.5 and HeatingUp) then
+    if CastLeft(S.FireBlast) then return "fire_blast standard_rotation 11"; end
+  end
   -- flamestrike,if=active_enemies>=variable.skb_flamestrike&buff.fury_of_the_sun_king.up&buff.fury_of_the_sun_king.expiration_delay_remains=0
   if AoEON() and S.Flamestrike:IsReady() and not Player:IsCasting(S.Flamestrike) and (EnemiesCount8ySplash >= VarSKBFlamestrike and Player:BuffUp(S.FuryoftheSunKingBuff)) then
     if Cast(S.Flamestrike, nil, nil, not Target:IsInRange(40)) then return "flamestrike standard_rotation 12"; end
@@ -595,8 +603,8 @@ local function StandardRotation()
       if Cast(S.DragonsBreath, Settings.Fire.GCDasOffGCD.DragonsBreath) then return "dragons_breath standard_rotation 28"; end
     end
   end
-  -- scorch,if=(scorch_execute.active|buff.heat_shimmer.react)
-  if S.Scorch:IsReady() and (ScorchExecuteActive() or Player:BuffUp(S.HeatShimmerBuff)) then
+  -- scorch,if=(scorch_execute.active&!(talent.unleashed_inferno&talent.frostfire_bolt)|buff.heat_shimmer.react)
+  if S.Scorch:IsReady() and ((ScorchExecuteActive() and not (S.UnleashedInferno:IsAvailable() and S.FrostfireBolt:IsAvailable())) or Player:BuffUp(S.HeatShimmerBuff)) then
     if Cast(S.Scorch, nil, nil, not Target:IsSpellInRange(S.Scorch)) then return "scorch standard_rotation 30"; end
   end
   -- arcane_explosion,if=active_enemies>=variable.arcane_explosion&mana.pct>=variable.arcane_explosion_mana
@@ -717,6 +725,10 @@ local function APL()
       if I.ImperfectAscendancySerum:IsEquippedAndReady() and (VarTimeToCombustion < 3) then
         if Cast(I.ImperfectAscendancySerum, nil, Settings.CommonsDS.DisplayStyle.Trinkets) then return "imperfect_ascendancy_serum main 10"; end
       end
+      -- use_item,name=neural_synapse_enhancer,if=buff.combustion.remains>7|fight_remains<15
+      if I.NeuralSynapseEnhancer:IsEquippedAndReady() and (CombustionRemains > 7 or FightRemains < 15) then
+        if Cast(I.NeuralSynapseEnhancer, nil, Settings.CommonsDS.DisplayStyle.Trinkets) then return "neural_synapse_enhancer main 11"; end
+      end
       -- use_item,effect_name=gladiators_badge,if=variable.time_to_combustion>cooldown-5
       if I.ForgedGladiatorsBadge:IsEquippedAndReady() and (VarTimeToCombustion > I.ForgedGladiatorsBadge:Cooldown() - 5) then
         if Cast(I.ForgedGladiatorsBadge, nil, Settings.CommonsDS.DisplayStyle.Trinkets) then return "gladiators_badge (forged) main 12"; end
@@ -746,7 +758,7 @@ local function APL()
       end
     end
     -- variable,use_off_gcd=1,use_while_casting=1,name=fire_blast_pooling,value=buff.combustion.down&action.fire_blast.charges_fractional+(variable.time_to_combustion+action.shifting_power.full_reduction*variable.shifting_power_before_combustion)%cooldown.fire_blast.duration-1<cooldown.fire_blast.max_charges+variable.overpool_fire_blasts%cooldown.fire_blast.duration-(buff.combustion.duration%cooldown.fire_blast.duration)%%1&variable.time_to_combustion<fight_remains
-    VarFireBlastPooling = CombustionDown and S.FireBlast:ChargesFractional() + (VarTimeToCombustion + ShiftingPowerFullReduction() * num(VarShiftingPowerBeforeCombustion)) / S.FireBlast:Cooldown() - 1 < S.FireBlast:MaxCharges() + VarOverpoolFireBlasts / S.FireBlast:Cooldown() - (12 / S.FireBlast:Cooldown()) % 1 and VarTimeToCombustion < FightRemains
+    VarFireBlastPooling = VarTimeToCombustion <= 8
     -- call_action_list,name=combustion_phase,if=variable.time_to_combustion<=0|buff.combustion.up|variable.time_to_combustion<variable.combustion_precast_time&cooldown.combustion.remains<variable.combustion_precast_time
     if VarTimeToCombustion <= 0 or CombustionUp or VarTimeToCombustion < VarCombustionPrecastTime and S.Combustion:CooldownRemains() < VarCombustionPrecastTime then
       local ShouldReturn = CombustionPhase(); if ShouldReturn then return ShouldReturn; end
@@ -794,7 +806,7 @@ local function APL()
 end
 
 local function Init()
-  HR.Print("Fire Mage rotation has been updated for patch 11.0.7.")
+  HR.Print("Fire Mage rotation has been updated for patch 11.1.0.")
 end
 
 HR.SetAPL(63, APL, Init)

--- a/HeroRotation_Mage/Fire.lua
+++ b/HeroRotation_Mage/Fire.lua
@@ -182,13 +182,14 @@ end, "PLAYER_REGEN_ENABLED")
 
 --- ===== Helper Functions =====
 local function ScorchExecuteActive()
-  if not S.Scorch:IsAvailable() then return false end
-  if Player:BuffUp(S.HeatShimmerBuff) then return true end
-  return Target:HealthPercentage() <= 30 + 5 * num(S.SunfuryExecution:IsAvailable())
+  if not Player or not Target then return false end
+  if S.SearingTouch:IsAvailable() and Target:HealthPercentage() <= 30 then return true end
+  return false
 end
 
 local function FirestarterActive()
-  return (S.Firestarter:IsAvailable() and (Target:HealthPercentage() > 90))
+  if not Player or not Target then return false end
+  return S.Firestarter:IsAvailable() and Target:HealthPercentage() >= 90
 end
 
 local function FirestarterRemains()
@@ -204,9 +205,15 @@ local function ShiftingPowerFullReduction()
 end
 
 local function FreeCastAvailable()
-  local FSInFlight = FirestarterActive() and (num(S.Pyroblast:InFlight()) + num(Bolt:InFlight())) or 0
-  FSInFlight = FSInFlight + num(S.PhoenixFlames:InFlight() or Player:PrevGCDP(1, S.PhoenixFlames))
-  return HotStreak or Player:BuffUp(S.HyperthermiaBuff) or (HeatingUp and (ImprovedScorchActive() and Player:IsCasting(S.Scorch) or FirestarterActive() and (Player:IsCasting(Bolt) or FSInFlight > 0)))
+  if not Player then return false end
+  -- Check for Hot Streak
+  local hotStreak = Player:BuffUp(S.HotStreakBuff)
+  -- Check for Hyperthermia
+  local hyperthermia = Player:BuffUp(S.HyperthermiaBuff)
+  -- Check for Fury of the Sun King
+  local furyOfTheSunKing = Player:BuffUp(S.FuryoftheSunKingBuff)
+
+  return hotStreak or hyperthermia or furyOfTheSunKing
 end
 
 local function UnitsWithIgnite(enemies)
@@ -220,11 +227,17 @@ local function UnitsWithIgnite(enemies)
 end
 
 local function HotStreakInFlight()
-  local total = 0
-  if Bolt:InFlight() or S.PhoenixFlames:InFlight() then
-    total = total + 1
-  end
-  return total
+  if not Player then return 0 end
+  local count = 0
+  -- Check Pyroblast in flight
+  if S.Pyroblast:InFlight() then count = count + 1 end
+  -- Check Fireball in flight
+  if S.Fireball:InFlight() then count = count + 1 end
+  -- Check Phoenix Flames in flight
+  if S.PhoenixFlames:InFlight() then count = count + 1 end
+  -- Check Frostfire Bolt in flight if available
+  if S.FrostfireBolt:IsAvailable() and S.FrostfireBolt:InFlight() then count = count + 1 end
+  return count
 end
 
 --- ===== Rotation Functions =====

--- a/HeroRotation_Mage/Mage.lua
+++ b/HeroRotation_Mage/Mage.lua
@@ -153,6 +153,7 @@ Spell.Mage.Fire = MergeTableByKey(Spell.Mage.Commons, {
   CalloftheSunKing                      = Spell(343222),
   Combustion                            = Spell(190319),
   FeeltheBurn                           = Spell(383391),
+  Firefall                              = Spell(384033),
   FlameAccelerant                       = Spell(203275),
   FireBlast                             = Spell(108853),
   Firestarter                           = Spell(205026),
@@ -263,6 +264,8 @@ Item.Mage.Fire = MergeTableByKey(Item.Mage.Commons, {
   VerdantGladiatorsBadge                = Item(209343, {13, 14}),
   -- TWW Gladiator's Badges
   ForgedGladiatorsBadge                 = Item(218713, {13, 14}),
+  -- TWW S2 Trinkets
+  NeuralSynapseEnhancer                 = Item(168973, {13, 14}),
   -- Trinkets kept for variables
   DragonfireBombDispenser               = Item(202610, {13, 14}),
   HornofValor                           = Item(133642, {13, 14}),

--- a/HeroRotation_Mage/Overrides.lua
+++ b/HeroRotation_Mage/Overrides.lua
@@ -106,13 +106,36 @@ ArcanePlayerBuffDown = HL.AddCoreOverride("Player.BuffDown",
 , 62)
 
 -- Fire, ID: 63
+local function IsSKBCastSafe(spell)
+  if not spell then return false end
+  -- Get precise aura data directly using C_UnitAuras to avoid recursion
+  local auraData = C_UnitAuras.GetPlayerAuraBySpellID(SpellFire.FuryoftheSunKingBuff:ID())
+  if auraData and auraData.expirationTime then
+    local currentTime = GetTimePreciseSec()
+    local remainingTime = auraData.expirationTime - currentTime
+    local castTime = spell:CastTime()
+    -- Add 0.2s buffer for spell queue window and latency
+    -- Also consider haste modifications via timeMod
+    return remainingTime > (castTime * (auraData.timeMod or 1) + 0.2)
+  end
+  return false
+end
+
 local FirePlayerBuffUp
 FirePlayerBuffUp = HL.AddCoreOverride("Player.BuffUp",
   function (self, Spell, AnyCaster, Offset)
+    if not Spell then return false end
     local BaseCheck = FirePlayerBuffUp(self, Spell, AnyCaster, Offset)
     if Spell == SpellFire.HeatingUpBuff then
       -- "Predictive" Heating Up buff for SKB Pyroblast casts...
-      return BaseCheck or Player:IsCasting(SpellFire.Pyroblast) and Player:BuffRemains(SpellFire.FuryoftheSunKingBuff) > 0
+      return BaseCheck or (Player:IsCasting(SpellFire.Pyroblast) and IsSKBCastSafe(SpellFire.Pyroblast))
+    elseif Spell == SpellFire.FuryoftheSunKingBuff then
+      -- Get aura data directly to avoid recursion
+      local auraData = C_UnitAuras.GetPlayerAuraBySpellID(Spell:ID())
+      if Player:IsCasting(SpellFire.Pyroblast) or Player:IsCasting(SpellFire.Flamestrike) then
+        return IsSKBCastSafe(Player:IsCasting(SpellFire.Pyroblast) and SpellFire.Pyroblast or SpellFire.Flamestrike)
+      end
+      return (auraData and auraData.expirationTime ~= nil) or BaseCheck
     else
       return BaseCheck
     end
@@ -124,7 +147,12 @@ FirePlayerBuffDown = HL.AddCoreOverride("Player.BuffDown",
   function (self, Spell, AnyCaster, Offset)
     local BaseCheck = FirePlayerBuffDown(self, Spell, AnyCaster, Offset)
     if Spell == SpellFire.FuryoftheSunKingBuff then
-      return BaseCheck or Player:IsCasting(SpellFire.Pyroblast)
+      -- Get aura data directly to avoid recursion
+      local auraData = C_UnitAuras.GetPlayerAuraBySpellID(Spell:ID())
+      if Player:IsCasting(SpellFire.Pyroblast) or Player:IsCasting(SpellFire.Flamestrike) then
+        return not IsSKBCastSafe(Player:IsCasting(SpellFire.Pyroblast) and SpellFire.Pyroblast or SpellFire.Flamestrike)
+      end
+      return auraData == nil and BaseCheck
     else
       return BaseCheck
     end
@@ -134,16 +162,18 @@ FirePlayerBuffDown = HL.AddCoreOverride("Player.BuffDown",
 HL.AddCoreOverride("Spell.IsReady",
   function (self, Range, AoESpell, ThisUnit, BypassRecovery, Offset)
     local BaseCheck = self:IsCastable() and self:IsUsableP()
-    local MovingOK = true
+    if not BaseCheck then return false end
+
     if self:CastTime() > 0 and Player:IsMoving() and Settings.Commons.MovingRotation then
-      if self == SpellFire.Scorch or (self == SpellFire.Pyroblast and Player:BuffUp(SpellFire.HotStreakBuff)) or (self == SpellFire.Flamestrike and Player:BuffUp(SpellFire.HotStreakBuff)) then
-        MovingOK = true
-      else
-        return false
+      if self == SpellFire.Scorch or
+         (self == SpellFire.Pyroblast and Player:BuffUp(SpellFire.HotStreakBuff)) or
+         (self == SpellFire.Flamestrike and Player:BuffUp(SpellFire.HotStreakBuff)) then
+        return true
       end
-    else
-      return BaseCheck
+      return false
     end
+
+    return true
   end
 , 63)
 


### PR DESCRIPTION
Improved Pyroblast and Flamestrike casts getting interrupted when Sun King buff expires. Now properly check if you have enough time to finish casting before starting, with a small buffer for lag.

Cilraz, I did this separately, since it's an improvement to the last commit I did which was just on the APL. Feel free to cancel them both if they deviate from what you intend for HR thanks.