### PR TITLE
improv: warlock code improvements

### DIFF
--- a/HeroRotation_Warlock/Events.lua
+++ b/HeroRotation_Warlock/Events.lua
@@ -309,8 +309,11 @@ end
 HL:RegisterForSelfCombatEvent(
   function (...)
     local timestamp,Event,_,SourceGUID,_,_,_,UnitPetGUID,_,_,_,SpellID=select(1,...)
-    local _, _, _, _, _, _, _, UnitPetID = find(UnitPetGUID, "(%S+)-(%d+)-(%d+)-(%d+)-(%d+)-(%d+)-(%S+)")
-    UnitPetID = tonumber(UnitPetID)
+    local UnitPetID = 0
+    if UnitPetGUID then
+        local _, _, _, _, _, _, _, id = find(UnitPetGUID, "(%S+)-(%d+)-(%d+)-(%d+)-(%d+)-(%d+)-(%S+)")
+        UnitPetID = tonumber(id or "0")
+    end
 
     -- Add pet
     if (UnitPetGUID ~= UnitGUID("pet") and Event == "SPELL_SUMMON" and PetsData[UnitPetID]) then

--- a/HeroRotation_Warlock/Warlock.lua
+++ b/HeroRotation_Warlock/Warlock.lua
@@ -113,7 +113,6 @@ Spell.Warlock.Affliction = MergeTableByKey(Spell.Warlock.Commons, {
   SoulSwap                              = Spell(386951),
   SoulTap                               = Spell(387073),
   SouleatersGluttony                    = Spell(389630),
-  SowtheSeeds                           = Spell(196226),
   TormentedCrescendo                    = Spell(387075),
   UnstableAffliction                    = Spell(316099),
   VileTaint                             = Spell(278350),


### PR DESCRIPTION
- Add safety check for pet ID parsing in Events.lua
- Remove redundant SowTheSeeds spell definition