### PR TITLE
feat(Fire): Do not recommend FBCast with Phoenix Flames

### DIFF
--- a/HeroRotation_Mage/Fire.lua
+++ b/HeroRotation_Mage/Fire.lua
@@ -629,7 +629,15 @@ end
 local function APL()
   -- Check which cast style we should use for Fire Blast/Pyroblast
   if Settings.Fire.ShowFireBlastLeft then
-    FBCast = CastLeft
+    FBCast = function(spell, displayStyle, displayOverride, rangeCheck)
+      -- If Phoenix Flames is currently recommended, don't show Fire Blast
+      if S.PhoenixFlames:IsCastable() and
+         (S.PhoenixFlames:CooldownUp() or S.PhoenixFlames:Charges() > 0) and
+         Target:IsSpellInRange(S.PhoenixFlames) then
+        return false
+      end
+      return CastLeft(spell)
+    end
   else
     FBCast = Cast
   end

--- a/HeroRotation_Mage/Fire.lua
+++ b/HeroRotation_Mage/Fire.lua
@@ -216,16 +216,16 @@ local function FreeCastAvailable()
   return hotStreak or hyperthermia or furyOfTheSunKing
 end
 
--- Currently unused. Left as a commented function for potential future use.
--- local function UnitsWithIgnite(enemies)
---   local WithIgnite = 0
---   for _, CycleUnit in pairs(enemies) do
---     if CycleUnit:DebuffUp(S.IgniteDebuff) then
---       WithIgnite = WithIgnite + 1
---     end
---   end
---   return WithIgnite
--- end
+-- Function to count units affected by Ignite
+local function UnitsWithIgnite(enemies)
+  local WithIgnite = 0
+  for _, CycleUnit in pairs(enemies) do
+    if CycleUnit:DebuffUp(S.IgniteDebuff) then
+      WithIgnite = WithIgnite + 1
+    end
+  end
+  return WithIgnite
+end
 
 local function HotStreakInFlight()
   if not Player then return 0 end
@@ -667,8 +667,7 @@ local function APL()
     end
 
     -- Check how many units have ignite
-    -- Note: Currently unused. Leaving in as a comment in case we need it later.
-    --UnitsWithIgniteCount = UnitsWithIgnite(Enemies8ySplash)
+    UnitsWithIgniteCount = UnitsWithIgnite(Enemies8ySplash)
 
     -- Get our Combustion status
     CombustionUp = Player:BuffUp(S.CombustionBuff)


### PR DESCRIPTION
To avoid confusion, FBCast should not be recommended when Phoenix Flames is recommended. FBCast still works fine for spells where its actually required and useful and simc conditions are right (not banking before combustion).