### PR TITLE
fix(Fire Mage): Remove SearingTouch talent and Improve Fireblast Pooling

### DIFF
--- a/HeroRotation_Mage/Fire.lua
+++ b/HeroRotation_Mage/Fire.lua
@@ -183,7 +183,7 @@ end, "PLAYER_REGEN_ENABLED")
 --- ===== Helper Functions =====
 local function ScorchExecuteActive()
   if not Player or not Target then return false end
-  if S.SearingTouch:IsAvailable() and Target:HealthPercentage() <= 30 then return true end
+  if Target:HealthPercentage() <= 30 then return true end
   return false
 end
 
@@ -682,7 +682,7 @@ local function APL()
     -- phoenix_flames,if=time=0
     -- Note: Moved to Precombat.
     -- Manually added: Scorch sniping
-    if Settings.Fire.UseScorchSniping and S.SearingTouch:IsAvailable() and AoEON() and Target:HealthPercentage() > 30 then
+    if Settings.Fire.UseScorchSniping and AoEON() and Target:HealthPercentage() > 30 then
       for _, CycleUnit in pairs(Enemies16ySplash) do
         if CycleUnit:Exists() and CycleUnit:GUID() ~= Target:GUID() and not CycleUnit:IsDeadOrGhost() and CycleUnit:HealthPercentage() < 30 and CycleUnit:IsSpellInRange(S.Scorch) then
           if HR.CastLeftNameplate(CycleUnit, S.Scorch) then return "Scorch Sniping on "..CycleUnit:Name().." main 2"; end
@@ -768,8 +768,10 @@ local function APL()
         end
       end
     end
-    -- variable,use_off_gcd=1,use_while_casting=1,name=fire_blast_pooling,value=buff.combustion.down&action.fire_blast.charges_fractional+(variable.time_to_combustion+action.shifting_power.full_reduction*variable.shifting_power_before_combustion)%cooldown.fire_blast.duration-1<cooldown.fire_blast.max_charges+variable.overpool_fire_blasts%cooldown.fire_blast.duration-(buff.combustion.duration%cooldown.fire_blast.duration)%%1&variable.time_to_combustion<fight_remains
-    VarFireBlastPooling = VarTimeToCombustion <= 8
+    -- Hardcoded value for fireblast pooling as per Simc.
+    -- Note: Simc default is 8 seconds, but top Fire Mages recommend 10 to 12 seconds for realistic usage.
+    -- variable,use_off_gcd=1,use_while_casting=1,name=fire_blast_pooling,value=variable.time_to_combustion<=11
+    VarFireBlastPooling = VarTimeToCombustion <= 11
     -- call_action_list,name=combustion_phase,if=variable.time_to_combustion<=0|buff.combustion.up|variable.time_to_combustion<variable.combustion_precast_time&cooldown.combustion.remains<variable.combustion_precast_time
     if VarTimeToCombustion <= 0 or CombustionUp or VarTimeToCombustion < VarCombustionPrecastTime and S.Combustion:CooldownRemains() < VarCombustionPrecastTime then
       local ShouldReturn = CombustionPhase(); if ShouldReturn then return ShouldReturn; end

--- a/HeroRotation_Mage/Mage.lua
+++ b/HeroRotation_Mage/Mage.lua
@@ -174,7 +174,6 @@ Spell.Mage.Fire = MergeTableByKey(Spell.Mage.Commons, {
   Quickflame                            = Spell(450807),
   Scald                                 = Spell(450746),
   Scorch                                = Spell(2948),
-  SearingTouch                          = Spell(269644),
   SpontaneousCombustion                 = Spell(451875),
   SunKingsBlessing                      = Spell(383886),
   UnleashedInferno                      = Spell(416506),


### PR DESCRIPTION
- Remove SearingTouch as it is no longer available, which also fixes Scorch sniping.
- Increase pooling duration from hardcoded 8 seconds (the default simc setting) to 11 seconds. This change reflects recommendations from Fire mages on the Altered Time Discord, around better Combustion setup.