### PR TITLE
feat(Unholy): Add Legion of Souls to GCD as OffGCD and DisplayStyle s…

### DIFF
--- a/HeroRotation_DeathKnight/Settings.lua
+++ b/HeroRotation_DeathKnight/Settings.lua
@@ -102,12 +102,14 @@ HR.GUISettings.APL.DeathKnight = {
     },
     DisplayStyle = {
       ArmyOfTheDead = "SuggestedRight",
+      LegionOfSouls = "SuggestedRight",
     },
     GCDasOffGCD = {
       -- Abilities4
       Apocalypse = false,
       DarkTransformation = true,
       Epidemic = false,
+      LegionofSouls = true,
       RaiseAbomination = false,
       SummonGargoyle = false,
       UnholyAssault = true,

--- a/HeroRotation_DeathKnight/Unholy.lua
+++ b/HeroRotation_DeathKnight/Unholy.lua
@@ -601,7 +601,7 @@ local function CDsShared()
   end
   -- legion_of_souls,if=(variable.st_planning|variable.adds_remain)&(death_knight.fwounded_targets<active_enemies|(cooldown.apocalypse.remains<3|cooldown.dark_transformation.remains<3))
   if S.LegionofSouls:IsReady() and ((VarSTPlanning or VarAddsRemain) and (FesterTargets < ActiveEnemies or (S.Apocalypse:CooldownRemains() < 3 or S.DarkTransformation:CooldownRemains() < 3))) then
-    if Cast(S.LegionofSouls, Settings.Unholy.GCDasOffGCD.LegionofSouls) then return "legion_of_souls cds_shared 8"; end
+    if Cast(S.LegionofSouls, Settings.Unholy.GCDasOffGCD.LegionofSouls, Settings.Unholy.DisplayStyle.LegionOfSouls) then return "legion_of_souls cds_shared 8"; end
   end
   -- summon_gargoyle,use_off_gcd=1,if=(variable.st_planning|variable.adds_remain)&(buff.commander_of_the_dead.up|!talent.commander_of_the_dead&active_enemies>=1)|fight_remains<25
   if S.SummonGargoyle:IsReady() and ((VarSTPlanning or VarAddsRemain) and (Player:BuffUp(S.CommanderoftheDeadBuff) or not S.CommanderoftheDead:IsAvailable() and ActiveEnemies >= 1) or BossFightRemains < 25) then


### PR DESCRIPTION
**Summary**
Adds configurable UI placement for Unholy’s Legion of Souls to match other DK cooldowns. By default, Legion of Souls displays in the right outer suggestion. Also adds an Off-GCD toggle for consistency with other Unholy abilities. No rotation logic or timings changed—only UI placement/config.

**Changes**

- Settings (Unholy)
- Added DisplayStyle.LegionOfSouls = "SuggestedRight"
- Added GCDasOffGCD.LegionofSouls = true
- Rotation wiring
- Pass DisplayStyle into the Legion of Souls Cast:
- Cast(S.LegionofSouls, Settings.Unholy.GCDasOffGCD.LegionofSouls, Settings.Unholy.DisplayStyle.LegionOfSouls)
- Options panel
- Uses CreateARPanelOptions(CP_Unholy, "APL.DeathKnight.Unholy") so the dropdown and toggle auto-generate.

**Files touched**

- [Settings.lua](vscode-file://vscode-app/c:/Users/jason/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Keys added: DisplayStyle.LegionOfSouls, GCDasOffGCD.LegionofSouls
- [Unholy.lua](vscode-file://vscode-app/c:/Users/jason/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- Updated Cast call for S.LegionofSouls to include DisplayStyle (3rd arg)

**UI**

- Unholy > Display Styles > Legion Of Souls: dropdown (e.g., Suggested, SuggestedLeft, SuggestedRight, Cooldown, etc.)
- Unholy > Off GCDs > Legion of Souls: checkbox

**Validation**

1. Tested in game. Works as expected.

**Notes**

- Naming follows existing conventions: DisplayStyle.LegionOfSouls and GCDasOffGCD.LegionofSouls.
- No changes to APL logic/conditions or timings—only UI placement/config.