### PR TITLE
fix: attempt to compare number with nil error.

### DIFF
--- a/HeroRotation_Shaman/Enhancement.lua
+++ b/HeroRotation_Shaman/Enhancement.lua
@@ -166,6 +166,8 @@ local function TotemFinder(Totem, ReturnTime)
       end
     end
   end
+  -- If totem not found, return appropriate default value.
+  return ReturnTime and 0 or false
 end
 
 local function AlphaWolfMinRemains()


### PR DESCRIPTION
139x HeroRotation_Shaman/Enhancement.lua:630: attempt to compare number with nil
[HeroRotation_Shaman/Enhancement.lua]:630: in function <HeroRotation_Shaman/Enhancement.lua:607>
[HeroRotation_Shaman/Enhancement.lua]:1640: in function '?'
[HeroRotation/Main.lua]:476: in function <HeroRotation/Main.lua:455>

Locals:
(*temporary) = nil
(*temporary) = <table> {
 LastCastTime = 0
 LastHitTime = 0
 LastAppliedOnPlayerTime = 0
 LastRemovedFromPlayerTime = 0
 SpellName = "Surging Totem"
 IsMelee = false
 SpellType = "Player"
 MaximumRange = 40
 MinimumRange = 0
 LastDisplayTime = 0
 SpellID = 444995
}
(*temporary) = true
(*temporary) = 6
(*temporary) = 6
(*temporary) = 1
(*temporary) = 6
(*temporary) = "attempt to compare number with nil"