### PR TITLE
fix(Demo): Typo Cleanups

### DIFF
--- a/HeroRotation_Warlock/Demonology.lua
+++ b/HeroRotation_Warlock/Demonology.lua
@@ -387,7 +387,7 @@ local function Items()
       -- use_item,use_off_gcd=1,slot=main_hand,name=neural_synapse_enhancer,if=(pet.demonic_tyrant.active|fight_remains<=15)&!variable.trinket_1_buffs&!variable.trinket_2_buffs
       ((DemonicTyrantActive() or BossFightRemains <= 15) and not VarTrinket1Buffs and not VarTrinket2Buffs) or
       -- use_item,use_off_gcd=1,slot=main_hand,name=neural_synapse_enhancer,if=(pet.demonic_tyrant.active|fight_remains<=15|trinket.2.cooldown.remains>cooldown.summon_demonic_tyrant.remains)&variable.trinket_2_buffs
-      ((DemonicTyrantActive() or BossFightRemains <= 15 or Trinket2:CooldownRemains() > S.SummonDemonicTyrant:CooldownRemains()) and VarTrinekt2Buffs) or
+      ((DemonicTyrantActive() or BossFightRemains <= 15 or Trinket2:CooldownRemains() > S.SummonDemonicTyrant:CooldownRemains()) and VarTrinket2Buffs) or
       -- use_item,use_off_gcd=1,slot=main_hand,name=neural_synapse_enhancer,if=(pet.demonic_tyrant.active|fight_remains<=15|trinket.1.cooldown.remains>cooldown.summon_demonic_tyrant.remains)&variable.trinket_1_buffs
       ((DemonicTyrantActive() or BossFightRemains <= 15 or Trinket1:CooldownRemains() > S.SummonDemonicTyrant:CooldownRemains()) and VarTrinket1Buffs)
     ) then
@@ -564,7 +564,7 @@ local function APL()
       if Cast(S.HandofGuldan, nil, nil, not Target:IsInRange(40)) then return "hand_of_guldan main 4"; end
     end
     -- summon_demonic_tyrant,if=(variable.imp_despawn&pet.vilefiend.active&pet.dreadstalker.active&(variable.imp_despawn<time+gcd.max+cast_time|buff.wild_imps.stack>=9-2*prev_gcd.1.hand_of_guldan))|(buff.grimoire_felguard.remains>cast_time&buff.grimoire_felguard.remains<action.hand_of_guldan.cast_time+cast_time+gcd.max)|(buff.dreadstalkers.remains>cast_time&((buff.dreadstalkers.remains<action.hand_of_guldan.cast_time+cast_time+gcd.max)|(variable.hog_after_ds&(time>10|buff.wild_imps.stack>=9-2*prev_gcd.1.hand_of_guldan))))
-    -- Note: Simc stores imp_despawn as an absolute time. We store is relative, so we don't need to add 'time'.
+    -- Note: Simc stores imp_despawn as an absolute time. We store it relative, so we don't need to add 'time'.
     if S.SummonDemonicTyrant:IsReady() and ((VarImpDespawn > 0 and VilefiendActive() and DreadstalkerActive() and (VarImpDespawn < Player:GCD() + S.SummonDemonicTyrant:CastTime() or WildImpsCount() >= 9 - 2 * num(Player:PrevGCDP(1, S.HandofGuldan)))) or (GrimoireFelguardTime() > S.SummonDemonicTyrant:CastTime() and GrimoireFelguardTime() < S.HandofGuldan:CastTime() + S.SummonDemonicTyrant:CastTime() + Player:GCD()) or (DreadstalkerTime() > S.SummonDemonicTyrant:CastTime() and ((DreadstalkerTime() < S.HandofGuldan:CastTime() + S.SummonDemonicTyrant:CastTime() + Player:GCD()) or (VarHoGAfterDS and (HL.CombatTime() > 10 or WildImpsCount() >= 9 - 2 * num(Player:PrevGCDP(1, S.HandofGuldan))))))) then
       if Cast(S.SummonDemonicTyrant, Settings.Demonology.GCDasOffGCD.SummonDemonicTyrant) then return "summon_demonic_tyrant main 6"; end
     end
@@ -586,9 +586,9 @@ local function APL()
       -- call_dreadstalkers,if=buff.vilefiend.up&buff.vilefiend.remains<12+gcd.max+cast_time
       (VilefiendActive() and VilefiendTime() < 12 + Player:GCD() + S.CallDreadstalkers:CastTime()) or
       -- call_dreadstalkers,if=cooldown.summon_demonic_tyrant.remains>cooldown+gcd.max+action.summon_demonic_tyrant.cast_time
-      (S.SummonDemonicTyrant:CooldownRemains() > 20 + Player:GCD() + S.SummonDemonicTyrant:CastTime()) or
+      (S.SummonDemonicTyrant:CooldownRemains() > Player:GCD() + S.SummonDemonicTyrant:CastTime()) or
       -- call_dreadstalkers,if=(!talent.grimoire_felguard|buff.grimoire_felguard.down&cooldown.grimoire_felguard.remains>cooldown-gcd.max-cast_time-action.summon_demonic_tyrant.cast_time)&(!talent.summon_vilefiend|buff.vilefiend.down>cooldown-gcd.max-cast_time-action.summon_demonic_tyrant.cast_time)
-      ((not S.GrimoireFelguard:IsAvailable() or not GrimoireFelguardActive() and S.GrimoireFelguard:CooldownRemains() > 20 - Player:GCD() - S.CallDreadstalkers:CastTime() - S.SummonDemonicTyrant:CastTime()) and (not S.SummonVilefiend:IsAvailable() or not VilefiendActive() and VilefiendAbility:CooldownRemains() > 20 - Player:GCD() - S.CallDreadstalkers:CastTime() - S.SummonDemonicTyrant:CastTime()))
+      ((not S.GrimoireFelguard:IsAvailable() or not GrimoireFelguardActive() and S.GrimoireFelguard:CooldownRemains() > S.SummonDemonicTyrant:Cooldown() - Player:GCD() - S.CallDreadstalkers:CastTime() - S.SummonDemonicTyrant:CastTime()) and (not S.SummonVilefiend:IsAvailable() or not VilefiendActive() and VilefiendAbility:CooldownRemains() > S.SummonDemonicTyrant:Cooldown() - Player:GCD() - S.CallDreadstalkers:CastTime() - S.SummonDemonicTyrant:CastTime()))
     ) then
       if Cast(S.CallDreadstalkers, nil, nil, not Target:IsSpellInRange(S.CallDreadstalkers)) then return "call_dreadstalkers main 14"; end
     end

--- a/HeroRotation_Warlock/Events.lua
+++ b/HeroRotation_Warlock/Events.lua
@@ -305,7 +305,7 @@ function Warlock.UpdatePetTable()
         Warlock.GuardiansTable.PitLordDuration = petTable.Duration
       elseif petTable.name == "Infernal" then
         Warlock.GuardiansTable.InfernalDuration = petTable.Duration
-      elseif petTable.name == "Blasphy" then
+      elseif petTable.name == "Blasphemy" then
         Warlock.GuardiansTable.BlasphemyDuration = petTable.Duration
       elseif petTable.name == "Overfiend" then
         Warlock.GuardiansTable.OverfiendDuration = petTable.Duration


### PR DESCRIPTION
- Fix typo: VarTrinekt2Buffs → VarTrinket2Buffs in Neural Synapse Enhancer logic
- Fix call_dreadstalkers: replace hardcoded 20 with S.SummonDemonicTyrant:Cooldown()
- Fix typo: Blasphy → Blasphemy in pet duration tracking