### PR TITLE
feat(Shadow): APL Improvements

### DIFF
--- a/HeroRotation_Priest/Priest.lua
+++ b/HeroRotation_Priest/Priest.lua
@@ -65,6 +65,9 @@ Spell.Priest.Commons = {
   SpymastersReportBuff        = Spell(451199), -- Stacking buff from before using Spymaster's Web trinket
   SpymastersWebBuff           = Spell(444959), -- Buff from using Spymaster's Web trinket
   TwistofFateBuff             = Spell(390978),
+  -- Nexus King's Command trinket buffs
+  OathboundBuff               = Spell(1239997),
+  BoonOfTheOathswornBuff      = Spell(1240578),
   -- Debuffs
   -- Other
   Pool                        = Spell(999910)
@@ -128,6 +131,7 @@ Spell.Priest.Shadow = MergeTableByKey(Spell.Priest.Commons, {
   ShadowCrashTarget           = Spell(457042),
   Silence                     = Spell(15487),
   UnfurlingDarkness           = Spell(341273),
+  Voidheart                   = Spell(449887),
   VoidTorrent                 = Spell(263165),
   Voidtouched                 = Spell(407430),
   VoidVolley                  = Spell(1242173),
@@ -143,6 +147,7 @@ Spell.Priest.Shadow = MergeTableByKey(Spell.Priest.Commons, {
   ShadowformBuff              = Spell(232698),
   UnfurlingDarknessBuff       = Spell(341282),
   VoidformBuff                = Spell(194249),
+  VoidheartBuff               = Spell(449887),
   VoidVolleyBuff              = Spell(1242171),
   -- Debuffs
   DevouringPlagueDebuff       = Spell(335467),
@@ -159,6 +164,7 @@ Item.Priest.Shadow = {
   AstralGladiatorsBadge       = Item(230638, {13, 14}),
   FlarendosPilotLight         = Item(230191, {13, 14}),
   GeargrindersSpareKeys       = Item(230197, {13, 14}),
+  NexusKingsCommand           = Item(242400, {13, 14}),
   PerfidiousProjector         = Item(242403, {13, 14}),
   PrizedGladiatorsBadge       = Item(229780, {13, 14}),
   SignetofthePriory           = Item(219308, {13, 14}),

--- a/HeroRotation_Priest/Shadow.lua
+++ b/HeroRotation_Priest/Shadow.lua
@@ -44,6 +44,7 @@ local OnUseExcludes = {
   I.FlarendosPilotLight:ID(),
   I.GeargrindersSpareKeys:ID(),
   I.NeuralSynapseEnhancer:ID(),
+  I.NexusKingsCommand:ID(),
   I.SpymastersWeb:ID(),
   -- TWW Other Items
   I.AstralGladiatorsBadge:ID(),
@@ -432,7 +433,7 @@ local function Trinkets()
       end
     end
     -- use_item,use_off_gcd=1,name=perfidious_projector,if=gcd.remains>0&(!talent.voidheart|buff.voidheart.up|fight_remains<20)
-    if I.PerfidiousProjector:IsEquippedAndReady() and (not S.Voidheard:IsAvailable() or Player:BuffUp(S.VoidheartBuff) or BossFightRemains < 20) then
+    if I.PerfidiousProjector:IsEquippedAndReady() and (not S.Voidheart:IsAvailable() or Player:BuffUp(S.VoidheartBuff) or BossFightRemains < 20) then
       if Cast(I.PerfidiousProjector, nil, Settings.CommonsDS.DisplayStyle.Trinkets, not Target:IsInRange(45)) then return "perfidious_projector trinkets 16"; end
     end
   end
@@ -478,8 +479,12 @@ local function CDs()
     -- invoke_external_buff,name=bloodlust,if=buff.power_infusion.up&fight_remains<120|fight_remains<=40
     -- Note: Not handling external buffs
     -- power_infusion,if=(buff.voidform.up|buff.dark_ascension.up&(fight_remains<=80|fight_remains>=140)|active_allied_augmentations)&(!buff.power_infusion.up|set_bonus.tww2_4pc&buff.power_infusion.remains<=15)
-    if S.PowerInfusion:IsCastable() and Settings.Shadow.SelfPI and ((Player:BuffUp(S.VoidformBuff) or Player:BuffUp(S.DarkAscension) and (BossFightRemains <= 80 or BossFightRemains >= 140)) and (Player:PowerInfusionDown() or Player:HasTier("TWW2", 4) and Player:PowerInfusionRemains() <= 15)) then
+    if S.PowerInfusion:IsCastable() and Settings.Shadow.SelfPI and ((Player:BuffUp(S.VoidformBuff) or Player:BuffUp(S.DarkAscensionBuff) and (BossFightRemains <= 80 or BossFightRemains >= 140)) and (Player:PowerInfusionDown() or Player:HasTier("TWW2", 4) and Player:PowerInfusionRemains() <= 15)) then
       if Cast(S.PowerInfusion, Settings.Shadow.OffGCDasOffGCD.PowerInfusion) then return "power_infusion cds 12"; end
+    end
+    -- flash_heal,if=equipped.nexuskings_command&buff.oathbound.up&(!buff.boon_of_the_oathsworn.up|buff.boon_of_the_oathsworn.remains<3)&((talent.void_eruption&(buff.voidform.up|cooldown.void_eruption.up))|(talent.dark_ascension&cooldown.dark_ascension.up)|(talent.power_surge&cooldown.halo.up)|(talent.entropic_rift&cooldown.void_torrent.up))
+    if S.FlashHeal:IsReady() and (I.NexusKingsCommand:IsEquipped() and Player:BuffUp(S.OathboundBuff) and (Player:BuffDown(S.BoonOfTheOathswornBuff) or Player:BuffRemains(S.BoonOfTheOathswornBuff) < 3) and ((S.VoidEruption:IsAvailable() and (Player:BuffUp(S.VoidformBuff) or S.VoidEruption:CooldownUp())) or (S.DarkAscension:IsAvailable() and S.DarkAscension:CooldownUp()) or (S.PowerSurge:IsAvailable() and S.Halo:CooldownUp()) or (S.EntropicRift:IsAvailable() and S.VoidTorrent:CooldownUp()))) then
+      if Cast(S.FlashHeal, nil, nil, not Target:IsSpellInRange(S.FlashHeal)) then return "flash_heal cds 13"; end
     end
     -- halo,if=talent.power_surge&(pet.fiend.active&cooldown.fiend.remains>=4&talent.mindbender|!talent.mindbender&!cooldown.fiend.up|active_enemies>2&!talent.inescapable_torment|!talent.dark_ascension)&(cooldown.mind_blast.charges=0|!cooldown.void_torrent.up|!talent.void_eruption|cooldown.void_eruption.remains>=gcd.max*4|buff.mind_devourer.up&talent.mind_devourer)
     if S.Halo:IsReady() and (S.PowerSurge:IsAvailable() and (FiendUp and Fiend:CooldownRemains() >= 4 and S.Mindbender:IsAvailable() or not S.Mindbender:IsAvailable() and Fiend:CooldownDown() or EnemiesCount10ySplash > 2 and not S.InescapableTorment:IsAvailable() or not S.DarkAscension:IsAvailable()) and (S.MindBlast:Charges() == 0 or S.VoidTorrent:CooldownDown() or not S.VoidEruption:IsAvailable() or S.VoidEruption:CooldownRemains() >= GCDMax * 4 or Player:BuffUp(S.MindDevourerBuff) and S.MindDevourer:IsAvailable())) then


### PR DESCRIPTION
- Added Nexus King's Command trinket and its associated buffs to Priest spell and item tables.
- Updated Shadow rotation logic to use Flash Heal with Oathbound and Boon of the Oathsworn buffs when the trinket is equipped.
- Also fixed a typo in the Power Infusion condition.