### PR TITLE
feat(Shadow): Minor Fixes

### DIFF
--- a/HeroRotation_Priest/Events.lua
+++ b/HeroRotation_Priest/Events.lua
@@ -81,9 +81,8 @@ local SpellShadow = Spell.Priest.Shadow
 
 -- Archon 4pc Helper
 HL:RegisterForSelfCombatEvent(
-  function(...)
+  function(_, Event, _, SourceGUID, _, _, _, DestGUID, _, _, _, SpellID)
     if Player:HeroTreeID() == 19 then
-      local Event, _, SourceGUID, _, _, _, DestGUID, _, _, _, SpellID = select(2, ...)
       if Event == "SPELL_AURA_REMOVED" and SpellID == SpellShadow.PowerSurgeBuff:ID() then
         -- Power Surge removed, reset variable
         Priest.Archon4pcStacks = 0

--- a/HeroRotation_Priest/Overrides.lua
+++ b/HeroRotation_Priest/Overrides.lua
@@ -12,7 +12,6 @@ local Item    = HL.Item
 local HR      = HeroRotation
 local num     = HR.Commons.Everyone.num
 -- Spells
-local SpellDisc    = Spell.Priest.Discipline
 local SpellShadow  = Spell.Priest.Shadow
 -- Lua
 -- WoW API
@@ -29,14 +28,18 @@ HL.AddCoreOverride ("Player.Insanity",
     else
       if Player:IsCasting(SpellShadow.MindBlast) then
         return Insanity + 6
-      elseif Player:IsCasting(SpellShadow.VampiricTouch) or Player:IsCasting(SpellShadow.MindSpike) then
+      elseif Player:IsCasting(SpellShadow.VampiricTouch) then
         return Insanity + 4
+      elseif Player:IsCasting(SpellShadow.MindSpike) or Player:IsCasting(SpellShadow.MindSpikeInsanity) then
+        return Insanity + 6
       elseif Player:IsCasting(SpellShadow.MindFlay) then
-        return Insanity + (12 / SpellShadow.MindFlay:BaseDuration())
+        return Insanity + (18 / SpellShadow.MindFlay:BaseDuration()) * Player:CastRemains()
+      elseif Player:IsCasting(SpellShadow.MindFlayInsanity) then
+        return Insanity + (8 / SpellShadow.MindFlayInsanity:BaseDuration()) * Player:CastRemains()
       elseif Player:IsCasting(SpellShadow.DarkAscension) then
         return Insanity + 30
       elseif Player:IsCasting(SpellShadow.VoidTorrent) then
-        return Insanity + (60 / SpellShadow.VoidTorrent:BaseDuration())
+        return Insanity + (24 / SpellShadow.VoidTorrent:BaseDuration()) * Player:CastRemains()
       else
         return Insanity
       end
@@ -65,7 +68,7 @@ OldShadowIsCastable = HL.AddCoreOverride("Spell.IsCastable",
   function (self, BypassRecovery, Range, AoESpell, ThisUnit, Offset)
     local BaseCheck = OldShadowIsCastable(self, BypassRecovery, Range, AoESpell, ThisUnit, Offset)
     if self == SpellShadow.VampiricTouch then
-      return BaseCheck and (not SpellShadow.ShadowCrash:InFlight() or SpellShadow.ShadowCrash:TimeSinceLastCast() > Player:GCD()) and (not SpellShadow.ShadowCrashTarget:InFlight() or SpellShadow.ShadowCrashTarget:TimeSinceLastCast() > Player:GCD()) and (SpellShadow.UnfurlingDarkness:IsAvailable() or not Player:IsCasting(self))
+      return BaseCheck and (not SpellShadow.ShadowCrash:InFlight() or SpellShadow.ShadowCrash:TimeSinceLastCast() > Player:GCD()) and (not SpellShadow.ShadowCrashTarget:InFlight() or SpellShadow.ShadowCrashTarget:TimeSinceLastCast() > Player:GCD()) and (Player:BuffUp(SpellShadow.UnfurlingDarknessBuff) or not Player:IsCasting(self))
     elseif self == SpellShadow.MindBlast then
       return BaseCheck and not (self:Charges() == 1 and Player:IsCasting(self))
     elseif self == SpellShadow.VoidEruption or self == SpellShadow.DarkAscension then

--- a/HeroRotation_Priest/Overrides.lua
+++ b/HeroRotation_Priest/Overrides.lua
@@ -40,6 +40,8 @@ HL.AddCoreOverride ("Player.Insanity",
         return Insanity + 30
       elseif Player:IsCasting(SpellShadow.VoidTorrent) then
         return Insanity + (24 / SpellShadow.VoidTorrent:BaseDuration()) * Player:CastRemains()
+      elseif Player:IsCasting(SpellShadow.VoidVolley) then
+        return Insanity + 10
       else
         return Insanity
       end

--- a/HeroRotation_Priest/Shadow.lua
+++ b/HeroRotation_Priest/Shadow.lua
@@ -247,7 +247,7 @@ end
 --- ===== CastTargetIf Condition Functions =====
 local function EvaluateTargetIfDPMain(TargetUnit)
   -- if=active_dot.devouring_plague<=1&dot.devouring_plague.remains<=gcd.max&(!talent.void_eruption|cooldown.void_eruption.remains>=gcd.max*3)|insanity.deficit<=35|buff.mind_devourer.up|buff.entropic_rift.up|buff.power_surge.up&buff.tww3_archon_4pc_helper.stack<4&buff.ascension.up
-  return S.DevouringPlagueDebuff:AuraActiveCount() <= 1 and Target:DebuffRemains(S.DevouringPlagueDebuff) <= GCDMax and (not S.VoidEruption:IsAvailable() or S.VoidEruption:CooldownRemains() >= GCDMax * 3) or Player:InsanityDeficit() <= 35 or Player:BuffUp(S.MindDevourerBuff) or EntropicRiftUp or Player:BuffUp(S.PowerSurgeBuff) and TWW3Archon4pcHelper() < 4 and Player:BuffUp(S.AscensionBuff)
+  return S.DevouringPlagueDebuff:AuraActiveCount() <= 1 and TargetUnit:DebuffRemains(S.DevouringPlagueDebuff) <= GCDMax and (not S.VoidEruption:IsAvailable() or S.VoidEruption:CooldownRemains() >= GCDMax * 3) or Player:InsanityDeficit() <= 35 or Player:BuffUp(S.MindDevourerBuff) or EntropicRiftUp or Player:BuffUp(S.PowerSurgeBuff) and TWW3Archon4pcHelper() < 4 and Player:BuffUp(S.AscensionBuff)
 end
 
 local function EvaluateTargetIfVoidBlastMain(TargetUnit)


### PR DESCRIPTION
- Fix EvaluateTargetIfDPMain using Target instead of TargetUnit parameter.
- Fix insanity prediction using CastTime() instead of CastRemains() for channels.
- Remove unused SpellDisc variable no longer used.
- Changed combat log handling to use direct parameter destructuring vs select().
- Fixed VT castability to check UnfurlingDarknessBuff state vs talent availability.
- Updated Void Torrent insanity calculation from 60 to 24 total insanity.
- Updated Mind Spike insanity prediction from 4 to 6 total insanity.
- Updated Mind Flay total insanity from 12 to 18 total insanity (6 ticks × 3 Insanity).
- Added Mind Flay: Insanity prediction with 8 total insanity (4 ticks × 2 Insanity).