### PR TITLE
feat(Windwalker): Minor Fixes

### DIFF
--- a/HeroRotation_Monk/Windwalker.lua
+++ b/HeroRotation_Monk/Windwalker.lua
@@ -125,7 +125,10 @@ if S.Paralysis:IsAvailable() then tinsert(Stuns, { S.Paralysis, "Cast Paralysis 
 
 --- ===== Event Registrations =====
 HL:RegisterForEvent(function()
+  Monk.Xuen.Active = false
   Monk.Xuen.Count = 0
+  Monk.Xuen.GUID = 0
+  Monk.Xuen.ExpireTime = 0
   BossFightRemains = 11111
   FightRemains = 11111
 end, "PLAYER_REGEN_ENABLED")
@@ -201,15 +204,15 @@ local function Trinkets()
     local T1Check = Trinket1 and Trinket1:IsReady() and not VarTrinket1Ex and not Player:IsItemBlacklisted(Trinket1)
     local T2Check = Trinket2 and Trinket2:IsReady() and not VarTrinket2Ex and not Player:IsItemBlacklisted(Trinket2)
     -- use_item,slot=trinket1,if=trinket.1.has_use_buff&trinket.2.has_use_buff&pet.xuen_the_white_tiger.active&variable.invoke_xuen_count%%2|fight_remains<20
-    if T1Check and (Trinket1:HasUseBuff() and Trinket2:HasUseBuff() and Monk.Xuen.Active and VarInvokeXuenCount % 2 == 1 or BossFightRemains < 20) then
+    if T1Check and ((Trinket1:HasUseBuff() and Trinket2:HasUseBuff() and Monk.Xuen.Active and Monk.Xuen.Count % 2 == 1) or BossFightRemains < 20) then
       if Cast(Trinket1, nil, Settings.CommonsDS.DisplayStyle.Trinkets, not Target:IsInRange(VarTrinket1Range)) then return "Generic use_items for " .. Trinket1:Name() .. " trinkets 2"; end
     end
     -- use_item,slot=trinket2,if=trinket.1.has_use_buff&trinket.2.has_use_buff&pet.xuen_the_white_tiger.active|fight_remains<20
-    if T2Check and (Trinket1:HasUseBuff() and Trinket2:HasUseBuff() and Monk.Xuen.Active or BossFightRemains < 20) then
+    if T2Check and ((Trinket1:HasUseBuff() and Trinket2:HasUseBuff() and Monk.Xuen.Active) or BossFightRemains < 20) then
       if Cast(Trinket2, nil, Settings.CommonsDS.DisplayStyle.Trinkets, not Target:IsInRange(VarTrinket2Range)) then return "Generic use_items for " .. Trinket2:Name() .. " trinkets 4"; end
     end
     -- use_item,slot=trinket1,if=trinket.1.has_use_buff&!trinket.2.has_use_buff&pet.xuen_the_white_tiger.active|fight_remains<20
-    if T1Check and (Trinket1:HasUseBuff() and not Trinket2:HasUseBuff() or Monk.Xuen.Active or BossFightRemains < 20) then
+    if T1Check and ((Trinket1:HasUseBuff() and not Trinket2:HasUseBuff() and Monk.Xuen.Active) or BossFightRemains < 20) then
       if Cast(Trinket1, nil, Settings.CommonsDS.DisplayStyle.Trinkets, not Target:IsInRange(VarTrinket1Range)) then return "Generic use_items for " .. Trinket1:Name() .. " trinkets 6"; end
     end
     -- use_item,slot=trinket2,if=trinket.1.has_use_buff&!trinket.2.has_use_buff&cooldown.invoke_xuen_the_white_tiger.remains>30|fight_remains<20
@@ -221,7 +224,7 @@ local function Trinkets()
       if Cast(Trinket1, nil, Settings.CommonsDS.DisplayStyle.Trinkets, not Target:IsInRange(VarTrinket1Range)) then return "Generic use_items for " .. Trinket1:Name() .. " trinkets 10"; end
     end
     -- use_item,slot=trinket2,if=!trinket.1.has_use_buff&trinket.2.has_use_buff&pet.xuen_the_white_tiger.active|fight_remains<20
-    if T2Check and (not Trinket1:HasUseBuff() and Trinket2:HasUseBuff() and Monk.Xuen.Active or BossFightRemains < 20) then
+    if T2Check and ((not Trinket1:HasUseBuff() and Trinket2:HasUseBuff() and Monk.Xuen.Active) or BossFightRemains < 20) then
       if Cast(Trinket2, nil, Settings.CommonsDS.DisplayStyle.Trinkets, not Target:IsInRange(VarTrinket2Range)) then return "Generic use_items for " .. Trinket2:Name() .. " trinkets 12"; end
     end
     -- use_item,slot=trinket1,if=!trinket.1.has_use_buff&!trinket.2.has_use_buff
@@ -992,6 +995,7 @@ local function APL()
     ChiDeficit = Player:ChiDeficit()
     Energy = Player:Energy()
     EnergyTTMCheck = Player:EnergyTimeToMax() <= Player:GCD() * 3
+    VarTotMMaxStacks = S.KnowledgeoftheBrokenTemple:IsAvailable() and 8 or 4
   end
 
   if Everyone.TargetIsValid() then


### PR DESCRIPTION
- Fix operator precedence in trinket usage conditions by adding parentheses.
- Make VarTotMMaxStacks dynamic based on Knowledge of the Broken Temple talent.
- Added Reset Xuen tracking variables (Active, Count, GUID, ExpireTime) on combat end.
- Fixed incorrect trinket usage when Xuen active but buff conditions not met.
- Added 8 vs 4 max stacks for Teaching of the Monastery buff.