### PR TITLE
fix(Warrior/Fury): Minor Code Changes

### DIFF
--- a/HeroRotation_Warrior/Fury.lua
+++ b/HeroRotation_Warrior/Fury.lua
@@ -122,7 +122,7 @@ local function SetTrinketVariables()
   local T1BuffDuration = (Trinket1:BuffDuration() > 0) and Trinket1:BuffDuration() or 1
   local T2BuffDuration = (Trinket2:BuffDuration() > 0) and Trinket2:BuffDuration() or 1
   VarTrinketPriority = 1
-  if not VarTrinket1Buffs and VarTrinket2Buffs or VarTrinket2Buffs and ((VarTrinket2CD / T2BuffDuration) * (VarTrinket2Sync)) > ((VarTrinket1CD / T1BuffDuration) * (VarTrinket1Sync)) then
+  if not VarTrinket1Buffs and VarTrinket2Buffs or VarTrinket2Buffs and ((VarTrinket2CD % T2BuffDuration) * (VarTrinket2Sync)) > ((VarTrinket1CD % T1BuffDuration) * (VarTrinket1Sync)) then
     VarTrinketPriority = 2
   end
 
@@ -177,7 +177,7 @@ local function Precombat()
     if Cast(I.TreacherousTransmitter, nil, Settings.CommonsDS.DisplayStyle.Trinkets) then return "treacherous_transmitter precombat 6"; end
   end
   -- recklessness,if=!equipped.fyralath_the_dreamrender
-  if CDsON() and S.Recklessness:IsCastable() then
+  if CDsON() and S.Recklessness:IsCastable() and not I.Fyralath:IsEquipped() then
     if Cast(S.Recklessness, Settings.Fury.GCDasOffGCD.Recklessness) then return "recklessness precombat 8"; end
   end
   -- avatar,if=!equipped.cursed_stone_idol

--- a/HeroRotation_Warrior/Overrides.lua
+++ b/HeroRotation_Warrior/Overrides.lua
@@ -67,7 +67,7 @@ FuryOldSpellIsReady = HL.AddCoreOverride ("Spell.IsReady",
   function (self, Range, AoESpell, ThisUnit, BypassRecovery, Offset)
     local BaseCheck = FuryOldSpellIsReady(self, Range, AoESpell, ThisUnit, BypassRecovery, Offset)
     if self == SpellFury.Rampage then
-      if Player:PrevGCDP(1, SpellFury.Bladestorm) then
+      if Player:PrevGCDP(1, SpellFury.Bladestorm) or Player:PrevGCDP(1, SpellFury.SlayerBladestorm) then
         return self:IsCastable() and Player:Rage() >= self:Cost()
       else
         return BaseCheck


### PR DESCRIPTION
- Rampage override: Check both Bladestorm and SlayerBladestorm in PrevGCDP to handle Unrelenting Onslaught talent
- Trinket priority: Use modulo instead of division in cooldown calculations to match SimC timing logic