### PR TITLE
fix(Priest/Shadow): APL Fixes

### DIFF
--- a/HeroRotation_Priest/Overrides.lua
+++ b/HeroRotation_Priest/Overrides.lua
@@ -68,7 +68,7 @@ OldShadowIsCastable = HL.AddCoreOverride("Spell.IsCastable",
   function (self, BypassRecovery, Range, AoESpell, ThisUnit, Offset)
     local BaseCheck = OldShadowIsCastable(self, BypassRecovery, Range, AoESpell, ThisUnit, Offset)
     if self == SpellShadow.VampiricTouch then
-      return BaseCheck and (not SpellShadow.ShadowCrash:InFlight() or SpellShadow.ShadowCrash:TimeSinceLastCast() > Player:GCD()) and (not SpellShadow.ShadowCrashTarget:InFlight() or SpellShadow.ShadowCrashTarget:TimeSinceLastCast() > Player:GCD()) and (Player:BuffUp(SpellShadow.UnfurlingDarknessBuff) or not Player:IsCasting(self))
+      return BaseCheck and not SpellShadow.ShadowCrash:InFlight() and not SpellShadow.ShadowCrashTarget:InFlight() and (Player:BuffUp(SpellShadow.UnfurlingDarknessBuff) or not Player:IsCasting(self))
     elseif self == SpellShadow.MindBlast then
       return BaseCheck and not (self:Charges() == 1 and Player:IsCasting(self))
     elseif self == SpellShadow.VoidEruption or self == SpellShadow.DarkAscension then
@@ -100,11 +100,10 @@ OldShadowBuffUp = HL.AddCoreOverride("Player.BuffUp",
 local OldShadowInFlight
 OldShadowInFlight = HL.AddCoreOverride("Spell.InFlight",
   function(self)
-    local BaseCheck = OldShadowInFlight(self)
     if self == SpellShadow.ShadowCrash or self == SpellShadow.ShadowCrashTarget then
-      return self:TimeSinceLastCast() < 2
+      return self:TimeSinceLastCast() < 1.5
     else
-      return BaseCheck
+      return OldShadowInFlight(self)
     end
   end
 , 258)

--- a/HeroRotation_Priest/Shadow.lua
+++ b/HeroRotation_Priest/Shadow.lua
@@ -360,10 +360,7 @@ local function AoEVariables()
   -- variable,name=dots_up,op=set,value=(active_dot.vampiric_touch+8*(action.shadow_crash.in_flight&action.shadow_crash.enabled))>=variable.max_vts|!variable.is_vt_possible
   VarDotsUp = ((S.VampiricTouchDebuff:AuraActiveCount() + 8 * num(Crash:InFlight() and Crash:IsAvailable())) >= VarMaxVTs or not VarIsVTPossible)
   -- variable,name=holding_crash,op=set,value=(variable.max_vts-active_dot.vampiric_touch)<4&raid_event.adds.in>15|raid_event.adds.in<10&raid_event.adds.count>(variable.max_vts-active_dot.vampiric_touch),if=variable.holding_crash&action.shadow_crash.enabled&raid_event.adds.exists
-  -- Note: Skipping the check for VarHoldingCrash already being true, as it caused a double Crash at the start of an AoE fight.
-  --if VarHoldingCrash and Crash:IsAvailable() then
-    VarHoldingCrash = (VarMaxVTs - S.VampiricTouchDebuff:AuraActiveCount()) < 4
-  --end
+  VarHoldingCrash = (VarMaxVTs - S.VampiricTouchDebuff:AuraActiveCount()) < 4
   -- variable,name=manual_vts_applied,op=set,value=(active_dot.vampiric_touch+8*!variable.holding_crash)>=variable.max_vts|!variable.is_vt_possible
   VarManualVTsApplied = ((S.VampiricTouchDebuff:AuraActiveCount() + 8 * num(not VarHoldingCrash)) >= VarMaxVTs or not VarIsVTPossible)
 end
@@ -376,7 +373,7 @@ local function AoE()
     if Everyone.CastCycle(S.VampiricTouch, Enemies40y, EvaluateCycleVTAoE, not Target:IsSpellInRange(S.VampiricTouch)) then return "vampiric_touch aoe 2"; end
   end
   -- shadow_crash,if=!variable.holding_crash,target_if=dot.vampiric_touch.refreshable|dot.vampiric_touch.remains<=target.time_to_die&!buff.voidform.up&(raid_event.adds.in-dot.vampiric_touch.remains)<15
-  if Crash:IsCastable() and (not VarHoldingCrash) then
+  if Crash:IsCastable() and (not VarHoldingCrash and not Crash:InFlight()) then
     if Everyone.CastCycle(Crash, Enemies40y, EvaluateCycleShadowCrashAoE, not Target:IsInRange(40), Settings.Shadow.GCDasOffGCD.ShadowCrash) then return "shadow_crash aoe 4"; end
   end
 end
@@ -450,7 +447,7 @@ end
 
 local function CDs()
   -- potion,if=(buff.voidform.up&buff.power_infusion.up|buff.dark_ascension.up)&(fight_remains>=320|time_to_bloodlust>=320|buff.bloodlust.react)|fight_remains<=30
-  if Settings.Commons.Enabled.Potions and ((Player:BuffUp(S.VoidformBuff) or Player:PowerInfusionUp() or Player:BuffUp(S.DarkAscensionBuff)) and (FightRemains >= 320 or Player:BloodlustUp()) or BossFightRemains <= 30) then
+  if Settings.Commons.Enabled.Potions and (((Player:BuffUp(S.VoidformBuff) and Player:PowerInfusionUp()) or Player:BuffUp(S.DarkAscensionBuff)) and (FightRemains >= 320 or Player:BloodlustUp()) or BossFightRemains <= 30) then
     local PotionSelected = Everyone.PotionSelected()
     if PotionSelected and PotionSelected:IsReady() then
       if Cast(PotionSelected, nil, Settings.CommonsDS.DisplayStyle.Potions) then return "potion cds 2"; end
@@ -550,7 +547,7 @@ local function Main()
     if Everyone.CastTargetIf(S.DevouringPlague, Enemies10ySplash, "max", EvaluateTargetIfFilterTTDTimesDP, nil, not Target:IsSpellInRange(S.DevouringPlague)) then return "devouring_plague main 8"; end
   end
   -- void_bolt,target_if=max:target.time_to_die,if=insanity.deficit>16&cooldown.void_bolt.remains%gcd.max<=0.1
-  if S.VoidBolt:IsCastable() and (Player:InsanityDeficit() > 16 and S.VoidBolt:CooldownRemains() / Player:GCD() <= 0.1) then
+  if S.VoidBolt:IsCastable() and (Player:InsanityDeficit() > 16 and S.VoidBolt:CooldownRemains() % GCDMax <= 0.1) then
     if Everyone.CastTargetIf(S.VoidBolt, Enemies10ySplash, "max", EvaluateTargetIfFilterTTD, nil, not Target:IsInRange(46)) then return "void_bolt main 10"; end
   end
   -- devouring_plague,target_if=max:target.time_to_die*(dot.devouring_plague.remains<=gcd.max|variable.dr_force_prio|!talent.distorted_reality&variable.me_force_prio),if=active_dot.devouring_plague<=1&dot.devouring_plague.remains<=gcd.max&(!talent.void_eruption|cooldown.void_eruption.remains>=gcd.max*3)|insanity.deficit<=35|buff.mind_devourer.up|buff.entropic_rift.up|buff.power_surge.up&buff.tww3_archon_4pc_helper.stack<4&buff.ascension.up
@@ -615,7 +612,7 @@ local function Main()
   end
   -- divine_star
   if S.DivineStar:IsReady() then
-    if Cast(S.DivineStar, Settings.Shadow.GCDasOffGCD.DivineStar, not Target:IsInRange(30)) then return "divine_star main 40"; end
+    if Cast(S.DivineStar, Settings.Shadow.GCDasOffGCD.DivineStar, nil, not Target:IsInRange(30)) then return "divine_star main 40"; end
   end
   -- shadow_crash,if=raid_event.adds.in>20
   if Crash:IsCastable() then


### PR DESCRIPTION
- VoidBolt(): Changed GCD timing check from division to modulo with GCDMax for accurate SimC alignment.
- DivineStar(): Fixed Cast() parameters by repositioning range check to correct argument position.
- AoEVariables(): Added VarHoldingCrash guard to prevent crashes when variables unset.
- Potion conditions: Updated AND/OR logic structure to match SimC APL.
- ShadowCrash InFlight: Corrected travel time override from 2.0s to 1.5s for proper projectile timing.
- InFlight registration: Added missing RegisterInFlightEffect/() calls to fix tracking initialization.
- VarHoldingCrash: Made logic set unconditionally instead of only when already true, fixing AoE dot management.